### PR TITLE
Refactor bulk email tools to accept typed arrays instead of JSON strings

### DIFF
--- a/src/CalendarMcp.Core/Tools/BulkMarkEmailsAsReadTool.cs
+++ b/src/CalendarMcp.Core/Tools/BulkMarkEmailsAsReadTool.cs
@@ -21,35 +21,25 @@ public sealed class BulkMarkEmailsAsReadTool(
 
     [McpServerTool, Description("Mark multiple emails as read or unread in a single batch operation. More efficient than calling mark_email_as_read repeatedly.")]
     public async Task<string> BulkMarkEmailsAsRead(
-        [Description("JSON array of objects with 'accountId' and 'emailId' fields. Example: [{\"accountId\":\"acct1\",\"emailId\":\"msg1\"}]. Maximum 50 items.")] string items,
+        [Description("Array of emails to mark, each with 'accountId' and 'emailId'. Maximum 50 items.")] BulkEmailItem[] items,
         [Description("True to mark as read, false to mark as unread (required)")] bool isRead)
     {
         logger.LogInformation("Bulk marking emails as {ReadStatus}", isRead ? "read" : "unread");
 
         try
         {
-            BulkEmailItem[]? parsedItems;
-            try
-            {
-                parsedItems = JsonSerializer.Deserialize<BulkEmailItem[]>(items);
-            }
-            catch (JsonException ex)
-            {
-                return JsonSerializer.Serialize(new { error = "Invalid items JSON format", message = ex.Message });
-            }
-
-            if (parsedItems == null || parsedItems.Length == 0)
+            if (items == null || items.Length == 0)
             {
                 return JsonSerializer.Serialize(new { error = "items array must not be empty" });
             }
 
-            if (parsedItems.Length > MaxBatchSize)
+            if (items.Length > MaxBatchSize)
             {
-                return JsonSerializer.Serialize(new { error = $"Batch size {parsedItems.Length} exceeds maximum of {MaxBatchSize}" });
+                return JsonSerializer.Serialize(new { error = $"Batch size {items.Length} exceeds maximum of {MaxBatchSize}" });
             }
 
             // Validate all items have required fields
-            foreach (var item in parsedItems)
+            foreach (var item in items)
             {
                 if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
                 {
@@ -58,9 +48,9 @@ public sealed class BulkMarkEmailsAsReadTool(
             }
 
             // Resolve accounts once per unique accountId
-            var accounts = await ResolveAccountsAsync(parsedItems);
+            var accounts = await ResolveAccountsAsync(items);
 
-            var results = await Task.WhenAll(parsedItems.Select(async item =>
+            var results = await Task.WhenAll(items.Select(async item =>
             {
                 await Throttle.WaitAsync();
                 try

--- a/src/CalendarMcp.Core/Tools/BulkMoveEmailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/BulkMoveEmailsTool.cs
@@ -21,7 +21,7 @@ public sealed class BulkMoveEmailsTool(
 
     [McpServerTool, Description("Move multiple emails to a folder or apply labels in a single batch operation. More efficient than calling move_email repeatedly.")]
     public async Task<string> BulkMoveEmails(
-        [Description("JSON array of objects with 'accountId' and 'emailId' fields. Example: [{\"accountId\":\"acct1\",\"emailId\":\"msg1\"}]. Maximum 50 items.")] string items,
+        [Description("Array of emails to move, each with 'accountId' and 'emailId'. Maximum 50 items.")] BulkEmailItem[] items,
         [Description("Destination folder or label for all emails: 'archive', 'inbox', 'trash', 'spam', 'drafts' (Microsoft only), 'sentitems' (Microsoft only), or custom label ID (Google only). Aliases: 'deleteditems'='trash', 'junkemail'='spam' (required)")] string destination)
     {
         logger.LogInformation("Bulk moving emails to {Destination}", destination);
@@ -33,28 +33,18 @@ public sealed class BulkMoveEmailsTool(
                 return JsonSerializer.Serialize(new { error = "destination is required" });
             }
 
-            BulkEmailItem[]? parsedItems;
-            try
-            {
-                parsedItems = JsonSerializer.Deserialize<BulkEmailItem[]>(items);
-            }
-            catch (JsonException ex)
-            {
-                return JsonSerializer.Serialize(new { error = "Invalid items JSON format", message = ex.Message });
-            }
-
-            if (parsedItems == null || parsedItems.Length == 0)
+            if (items == null || items.Length == 0)
             {
                 return JsonSerializer.Serialize(new { error = "items array must not be empty" });
             }
 
-            if (parsedItems.Length > MaxBatchSize)
+            if (items.Length > MaxBatchSize)
             {
-                return JsonSerializer.Serialize(new { error = $"Batch size {parsedItems.Length} exceeds maximum of {MaxBatchSize}" });
+                return JsonSerializer.Serialize(new { error = $"Batch size {items.Length} exceeds maximum of {MaxBatchSize}" });
             }
 
             // Validate all items have required fields
-            foreach (var item in parsedItems)
+            foreach (var item in items)
             {
                 if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
                 {
@@ -63,9 +53,9 @@ public sealed class BulkMoveEmailsTool(
             }
 
             // Resolve accounts once per unique accountId
-            var accounts = await ResolveAccountsAsync(parsedItems);
+            var accounts = await ResolveAccountsAsync(items);
 
-            var results = await Task.WhenAll(parsedItems.Select(async item =>
+            var results = await Task.WhenAll(items.Select(async item =>
             {
                 await Throttle.WaitAsync();
                 try

--- a/src/CalendarMcp.Core/Tools/DiagnosticEchoTool.cs
+++ b/src/CalendarMcp.Core/Tools/DiagnosticEchoTool.cs
@@ -14,27 +14,16 @@ public sealed class DiagnosticEchoTool(ILogger<DiagnosticEchoTool> logger)
 {
     [McpServerTool, Description("Diagnostic: echoes back the received arguments for debugging. Test with array parameter.")]
     public Task<string> DiagnosticEcho(
-        [Description("JSON array of objects with 'accountId' and 'emailId' fields.")] string items,
+        [Description("Array of objects with 'accountId' and 'emailId' fields.")] BulkEmailItem[] items,
         [Description("A simple string parameter")] string label)
     {
-        logger.LogWarning("DiagnosticEcho called: items={Items}, label={Label}", items, label);
-
-        BulkEmailItem[]? parsedItems = null;
-        try
-        {
-            parsedItems = JsonSerializer.Deserialize<BulkEmailItem[]>(items);
-        }
-        catch (JsonException ex)
-        {
-            logger.LogWarning(ex, "Failed to parse items JSON");
-        }
+        logger.LogWarning("DiagnosticEcho called: itemCount={ItemCount}, label={Label}", items?.Length ?? 0, label);
 
         var response = new
         {
-            receivedItemsCount = parsedItems?.Length ?? 0,
+            receivedItemsCount = items?.Length ?? 0,
             receivedLabel = label,
-            rawItems = items,
-            items = parsedItems?.Select(i => new { i.AccountId, i.EmailId })
+            items = items?.Select(i => new { i.AccountId, i.EmailId })
         };
 
         return Task.FromResult(JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true }));

--- a/src/CalendarMcp.Tests/Tools/BulkDeleteEmailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/BulkDeleteEmailsToolTests.cs
@@ -19,7 +19,7 @@ public class BulkDeleteEmailsToolTests
         var tool = new BulkDeleteEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkDeleteEmailsTool>.Instance);
 
-        var result = await tool.BulkDeleteEmails("[]");
+        var result = await tool.BulkDeleteEmails([]);
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual("items array must not be empty", doc.RootElement.GetProperty("error").GetString());
@@ -37,7 +37,7 @@ public class BulkDeleteEmailsToolTests
             .Select(i => new BulkEmailItem { AccountId = "acc-1", EmailId = $"email-{i}" })
             .ToArray();
 
-        var result = await tool.BulkDeleteEmails(JsonSerializer.Serialize(emails));
+        var result = await tool.BulkDeleteEmails(emails);
         var doc = JsonDocument.Parse(result);
 
         Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("exceeds maximum"));
@@ -64,12 +64,11 @@ public class BulkDeleteEmailsToolTests
         var tool = new BulkDeleteEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkDeleteEmailsTool>.Instance);
 
-        var emails = JsonSerializer.Serialize(new[]
-        {
+        var result = await tool.BulkDeleteEmails(
+        [
             new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" },
             new BulkEmailItem { AccountId = "acc-1", EmailId = "e2" }
-        });
-        var result = await tool.BulkDeleteEmails(emails);
+        ]);
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual(2, doc.RootElement.GetProperty("totalRequested").GetInt32());
@@ -92,8 +91,7 @@ public class BulkDeleteEmailsToolTests
         var tool = new BulkDeleteEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkDeleteEmailsTool>.Instance);
 
-        var emails = JsonSerializer.Serialize(new[] { new BulkEmailItem { AccountId = "missing", EmailId = "e1" } });
-        var result = await tool.BulkDeleteEmails(emails);
+        var result = await tool.BulkDeleteEmails([new BulkEmailItem { AccountId = "missing", EmailId = "e1" }]);
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual(1, doc.RootElement.GetProperty("totalRequested").GetInt32());

--- a/src/CalendarMcp.Tests/Tools/BulkMarkEmailsAsReadToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/BulkMarkEmailsAsReadToolTests.cs
@@ -19,7 +19,7 @@ public class BulkMarkEmailsAsReadToolTests
         var tool = new BulkMarkEmailsAsReadTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMarkEmailsAsReadTool>.Instance);
 
-        var result = await tool.BulkMarkEmailsAsRead("[]", true);
+        var result = await tool.BulkMarkEmailsAsRead([], true);
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual("items array must not be empty", doc.RootElement.GetProperty("error").GetString());
@@ -44,8 +44,7 @@ public class BulkMarkEmailsAsReadToolTests
         var tool = new BulkMarkEmailsAsReadTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMarkEmailsAsReadTool>.Instance);
 
-        var emails = JsonSerializer.Serialize(new[] { new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" } });
-        var result = await tool.BulkMarkEmailsAsRead(emails, true);
+        var result = await tool.BulkMarkEmailsAsRead([new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" }], true);
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual(1, doc.RootElement.GetProperty("succeeded").GetInt32());

--- a/src/CalendarMcp.Tests/Tools/BulkMoveEmailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/BulkMoveEmailsToolTests.cs
@@ -19,8 +19,7 @@ public class BulkMoveEmailsToolTests
         var tool = new BulkMoveEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMoveEmailsTool>.Instance);
 
-        var emails = JsonSerializer.Serialize(new[] { new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" } });
-        var result = await tool.BulkMoveEmails(emails, "");
+        var result = await tool.BulkMoveEmails([new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" }], "");
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual("destination is required", doc.RootElement.GetProperty("error").GetString());
@@ -34,7 +33,7 @@ public class BulkMoveEmailsToolTests
         var tool = new BulkMoveEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMoveEmailsTool>.Instance);
 
-        var result = await tool.BulkMoveEmails("[]", "archive");
+        var result = await tool.BulkMoveEmails([], "archive");
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual("items array must not be empty", doc.RootElement.GetProperty("error").GetString());
@@ -59,8 +58,7 @@ public class BulkMoveEmailsToolTests
         var tool = new BulkMoveEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMoveEmailsTool>.Instance);
 
-        var emails = JsonSerializer.Serialize(new[] { new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" } });
-        var result = await tool.BulkMoveEmails(emails, "archive");
+        var result = await tool.BulkMoveEmails([new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" }], "archive");
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual(1, doc.RootElement.GetProperty("succeeded").GetInt32());


### PR DESCRIPTION
## Summary

- Replace `string` parameters (requiring manual JSON parsing) with `BulkEmailItem[]` in `BulkDeleteEmails`, `BulkMarkEmailsAsRead`, `BulkMoveEmails`, and `DiagnosticEcho` tools
- The MCP framework now handles deserialization directly, eliminating try/catch JSON parsing blocks in each tool
- Update tests to pass typed arrays instead of serialized JSON strings

## Test plan

- [ ] All existing bulk email tool tests pass with the new signatures
- [ ] Verify MCP clients can invoke bulk operations with array parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)