### PR TITLE
Add account capabilities and fix JSON email deserialization

### DIFF
--- a/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
@@ -1072,15 +1072,19 @@ internal class JsonEmailEntry
     public string? Subject { get; set; }
 
     [JsonPropertyName("from")]
+    [JsonConverter(typeof(JsonRecipientConverter))]
     public JsonRecipient? From { get; set; }
 
     [JsonPropertyName("toRecipients")]
+    [JsonConverter(typeof(JsonRecipientListConverter))]
     public List<JsonRecipient>? ToRecipients { get; set; }
 
     [JsonPropertyName("ccRecipients")]
+    [JsonConverter(typeof(JsonRecipientListConverter))]
     public List<JsonRecipient>? CcRecipients { get; set; }
 
     [JsonPropertyName("body")]
+    [JsonConverter(typeof(JsonBodyConverter))]
     public JsonBody? Body { get; set; }
 
     [JsonPropertyName("bodyPreview")]
@@ -1109,4 +1113,107 @@ internal class JsonBody
 
     [JsonPropertyName("contentType")]
     public string? ContentType { get; set; }
+}
+
+/// <summary>
+/// Handles both string ("body": "text") and object ("body": {"content":"...","contentType":"..."}) formats.
+/// </summary>
+internal class JsonBodyConverter : JsonConverter<JsonBody?>
+{
+    public override JsonBody? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+
+        if (reader.TokenType == JsonTokenType.String)
+            return new JsonBody { Content = reader.GetString(), ContentType = "text" };
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+            return JsonSerializer.Deserialize<JsonBody>(ref reader);
+
+        reader.Skip();
+        return null;
+    }
+
+    public override void Write(Utf8JsonWriter writer, JsonBody? value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, value, options);
+}
+
+/// <summary>
+/// Handles recipient lists that may contain strings, objects, or be a single string.
+/// Supports: ["a@b.com"], [{"emailAddress":{"address":"a@b.com"}}], "a@b.com", or mixed arrays.
+/// </summary>
+internal class JsonRecipientListConverter : JsonConverter<List<JsonRecipient>?>
+{
+    public override List<JsonRecipient>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            return string.IsNullOrEmpty(value) ? [] :
+                [new JsonRecipient { EmailAddress = new JsonEmailAddress { Address = value, Name = value } }];
+        }
+
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            var list = new List<JsonRecipient>();
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                if (reader.TokenType == JsonTokenType.String)
+                {
+                    var addr = reader.GetString();
+                    list.Add(new JsonRecipient { EmailAddress = new JsonEmailAddress { Address = addr, Name = addr } });
+                }
+                else if (reader.TokenType == JsonTokenType.StartObject)
+                {
+                    var recipient = JsonSerializer.Deserialize<JsonRecipient>(ref reader);
+                    if (recipient != null) list.Add(recipient);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+            return list;
+        }
+
+        reader.Skip();
+        return null;
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<JsonRecipient>? value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, value, options);
+}
+
+/// <summary>
+/// Handles both string ("from": "email@example.com") and object ("from": {"emailAddress":{"address":"..."}}) formats.
+/// </summary>
+internal class JsonRecipientConverter : JsonConverter<JsonRecipient?>
+{
+    public override JsonRecipient? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            return new JsonRecipient
+            {
+                EmailAddress = new JsonEmailAddress { Address = value, Name = value }
+            };
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+            return JsonSerializer.Deserialize<JsonRecipient>(ref reader);
+
+        reader.Skip();
+        return null;
+    }
+
+    public override void Write(Utf8JsonWriter writer, JsonRecipient? value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, value, options);
 }

--- a/src/CalendarMcp.Core/Tools/ListAccountsTool.cs
+++ b/src/CalendarMcp.Core/Tools/ListAccountsTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -14,7 +15,7 @@ public sealed class ListAccountsTool(
     IAccountRegistry accountRegistry,
     ILogger<ListAccountsTool> logger)
 {
-    [McpServerTool, Description("List all configured email and calendar accounts. Returns accountId, provider, displayName, and domains for each. Use the accountId values when calling other tools to scope operations to a specific account.")]
+    [McpServerTool, Description("List all configured accounts with their capabilities. Returns accountId, provider, displayName, domains, and capabilities (calendar, email, contacts) for each. Use the accountId values when calling other tools to scope operations to a specific account.")]
     public async Task<string> ListAccounts()
     {
         logger.LogInformation("Listing all accounts");
@@ -30,7 +31,8 @@ public sealed class ListAccountsTool(
                     accountId = a.Id,
                     provider = a.Provider,
                     displayName = a.DisplayName,
-                    domains = a.Domains
+                    domains = a.Domains,
+                    capabilities = GetAccountCapabilities(a)
                 })
             };
 
@@ -48,5 +50,65 @@ public sealed class ListAccountsTool(
                 message = ex.Message
             });
         }
+    }
+
+    /// <summary>
+    /// Determines capabilities for an account based on its provider type and configuration.
+    /// </summary>
+    private static List<object> GetAccountCapabilities(AccountInfo account)
+    {
+        var provider = account.Provider.ToLowerInvariant();
+
+        return provider switch
+        {
+            "microsoft365" or "m365" => [
+                new { name = "calendar", readOnly = false },
+                new { name = "email", readOnly = false },
+                new { name = "contacts", readOnly = false }
+            ],
+            "google" or "gmail" or "google workspace" => [
+                new { name = "calendar", readOnly = false },
+                new { name = "email", readOnly = false },
+                new { name = "contacts", readOnly = false }
+            ],
+            "outlook.com" or "outlook" or "hotmail" => [
+                new { name = "calendar", readOnly = false },
+                new { name = "email", readOnly = false },
+                new { name = "contacts", readOnly = false }
+            ],
+            "ics" or "icalendar" => [
+                new { name = "calendar", readOnly = true }
+            ],
+            "json" or "json-calendar" => GetJsonCapabilities(account),
+            _ => [
+                new { name = "calendar", readOnly = false }
+            ]
+        };
+    }
+
+    /// <summary>
+    /// JSON accounts have optional email and contacts support depending on configured file paths.
+    /// </summary>
+    private static List<object> GetJsonCapabilities(AccountInfo account)
+    {
+        var config = account.ProviderConfig;
+        var capabilities = new List<object>
+        {
+            new { name = "calendar", readOnly = true }
+        };
+
+        if (config.ContainsKey("emailsFilePath") && !string.IsNullOrEmpty(config["emailsFilePath"])
+            || config.ContainsKey("emailsOneDrivePath") && !string.IsNullOrEmpty(config["emailsOneDrivePath"]))
+        {
+            capabilities.Add(new { name = "email", readOnly = true });
+        }
+
+        if (config.ContainsKey("contactsFilePath") && !string.IsNullOrEmpty(config["contactsFilePath"])
+            || config.ContainsKey("contactsOneDrivePath") && !string.IsNullOrEmpty(config["contactsOneDrivePath"]))
+        {
+            capabilities.Add(new { name = "contacts", readOnly = true });
+        }
+
+        return capabilities;
     }
 }

--- a/src/CalendarMcp.HttpServer/Program.cs
+++ b/src/CalendarMcp.HttpServer/Program.cs
@@ -29,23 +29,20 @@ public class Program
 
         var otlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
 
-        // If no OTLP endpoint, use Serilog for file + console logging
-        if (string.IsNullOrEmpty(otlpEndpoint))
-        {
-            Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Information()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-                .Enrich.FromLogContext()
-                .WriteTo.Console(
-                    outputTemplate: "{Timestamp:HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
-                .WriteTo.File(
-                    path: Path.Combine(logDir, "calendar-mcp-http-.log"),
-                    rollingInterval: RollingInterval.Day,
-                    retainedFileCountLimit: 7,
-                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
-                .CreateLogger();
-        }
+        // Always configure Serilog for file logging
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+            .Enrich.FromLogContext()
+            .WriteTo.Console(
+                outputTemplate: "{Timestamp:HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+            .WriteTo.File(
+                path: Path.Combine(logDir, "calendar-mcp-http-.log"),
+                rollingInterval: RollingInterval.Day,
+                retainedFileCountLimit: 7,
+                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+            .CreateLogger();
 
         Log.Information("Calendar MCP HTTP Server starting. Config directory: {ConfigDir}", configDir);
 
@@ -78,10 +75,10 @@ public class Program
         // Add environment variables (can override file settings)
         builder.Configuration.AddEnvironmentVariables("CALENDAR_MCP_");
 
-        // Configure logging
+        // Configure logging - always use Serilog, add OTEL if endpoint is available
+        builder.Host.UseSerilog();
         if (!string.IsNullOrEmpty(otlpEndpoint))
         {
-            builder.Logging.ClearProviders();
             builder.Logging.AddOpenTelemetry(options =>
             {
                 options.SetResourceBuilder(ResourceBuilder.CreateDefault()
@@ -90,10 +87,6 @@ public class Program
                 options.IncludeFormattedMessage = true;
                 options.IncludeScopes = true;
             });
-        }
-        else
-        {
-            builder.Host.UseSerilog();
         }
 
         // Configure Calendar MCP settings


### PR DESCRIPTION
## Summary
- **list_accounts** now returns per-account `capabilities` array (calendar, email, contacts) with `readOnly` flags, so LLM consumers know what each account supports
- Fixed JSON email deserialization failure where `body`, `from`, `toRecipients`, and `ccRecipients` fields could be plain strings instead of Graph API objects — added custom JsonConverters to handle both formats
- HTTP server now always writes Serilog file logs, with OTEL added on top when configured (previously either/or)

## Test plan
- [x] Verified `list_accounts` returns capabilities for all provider types (M365, Google, Outlook.com, ICS, JSON)
- [x] Verified `get_emails` returns emails from Xebia JSON/OneDrive account
- [x] Verified `get_contacts` returns contacts from Xebia JSON/OneDrive account
- [x] Verified calendar still works for Xebia account
- [x] Tested live on k8s cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)