### PR TITLE
Add assembly versioning via Directory.Build.props (1.1.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.1.0</VersionPrefix>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Adds a repo-root `Directory.Build.props` setting `<VersionPrefix>1.1.0</VersionPrefix>`
- MSBuild auto-imports it into all six projects, so every assembly now builds as `1.1.0.0` instead of the SDK default `1.0.0.0`
- Bumping the version going forward is a one-line edit in this file

## Test plan
- [ ] `dotnet build` succeeds
- [ ] Verify assembly metadata (e.g., `Get-Item bin/Debug/net*/CalendarMcp.*.dll | % VersionInfo`) reports `1.1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)