### PR TITLE
Fix Google OAuth start failing for UI-created accounts (case-insensitive ProviderConfig)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy project files for layer caching
+# Directory.Build.props lives at the repo root and is auto-imported by MSBuild
+# from the parent of each .csproj, so we drop it next to the projects in /src.
+COPY Directory.Build.props ./
 COPY src/CalendarMcp.Core/CalendarMcp.Core.csproj CalendarMcp.Core/
 COPY src/CalendarMcp.Auth/CalendarMcp.Auth.csproj CalendarMcp.Auth/
 COPY src/CalendarMcp.HttpServer/CalendarMcp.HttpServer.csproj CalendarMcp.HttpServer/

--- a/src/CalendarMcp.Auth/AccountConfigurationService.cs
+++ b/src/CalendarMcp.Auth/AccountConfigurationService.cs
@@ -331,7 +331,7 @@ public sealed class AccountConfigurationService : IAccountConfigurationService
         var dictObj = obj[pascalName]?.AsObject() ?? obj[camelName]?.AsObject();
         if (dictObj is null) return [];
 
-        var result = new Dictionary<string, string>();
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var prop in dictObj)
         {
             if (prop.Value is not null)

--- a/src/CalendarMcp.Cli/Commands/ReauthenticateAccountCommand.cs
+++ b/src/CalendarMcp.Cli/Commands/ReauthenticateAccountCommand.cs
@@ -108,14 +108,14 @@ public class ReauthenticateAccountCommand : AsyncCommand<ReauthenticateAccountCo
                 return 1;
             }
 
-            var providerConfig = providerConfigElem.Deserialize<Dictionary<string, string>>()
-                ?? new Dictionary<string, string>();
+            var providerConfig = new Dictionary<string, string>(
+                providerConfigElem.Deserialize<Dictionary<string, string>>() ?? new(),
+                StringComparer.OrdinalIgnoreCase);
 
             // For JSON accounts with authAccountId, redirect to reauth the referenced account
             if (provider is "json" or "json-calendar")
             {
-                if (providerConfig.TryGetValue("authAccountId", out var authAcctId) ||
-                    providerConfig.TryGetValue("AuthAccountId", out authAcctId))
+                if (providerConfig.TryGetValue("authAccountId", out var authAcctId))
                 {
                     AnsiConsole.MarkupLine($"[yellow]JSON account '{settings.AccountId}' uses credentials from account '{authAcctId}'.[/]");
                     AnsiConsole.MarkupLine($"[yellow]Reauthenticating '{authAcctId}' instead (with Files.Read scope)...[/]");
@@ -139,7 +139,9 @@ public class ReauthenticateAccountCommand : AsyncCommand<ReauthenticateAccountCo
                         return 1;
                     }
 
-                    var refProviderConfig = refPcElem.Deserialize<Dictionary<string, string>>() ?? new();
+                    var refProviderConfig = new Dictionary<string, string>(
+                        refPcElem.Deserialize<Dictionary<string, string>>() ?? new(),
+                        StringComparer.OrdinalIgnoreCase);
                     string? refProvider = null;
                     if (refAccount.TryGetValue("Provider", out var refProvElem) || refAccount.TryGetValue("provider", out refProvElem))
                         refProvider = refProvElem.GetString();
@@ -197,11 +199,8 @@ public class ReauthenticateAccountCommand : AsyncCommand<ReauthenticateAccountCo
     private async Task<int> ReauthenticateMicrosoftAccountAsync(string accountId, Dictionary<string, string> providerConfig, string provider,
         List<Dictionary<string, JsonElement>>? allAccounts = null)
     {
-        // Try both PascalCase and camelCase for config keys
-        if (!providerConfig.TryGetValue("TenantId", out var tenantId))
-            providerConfig.TryGetValue("tenantId", out tenantId);
-        if (!providerConfig.TryGetValue("ClientId", out var clientId))
-            providerConfig.TryGetValue("clientId", out clientId);
+        providerConfig.TryGetValue("tenantId", out var tenantId);
+        providerConfig.TryGetValue("clientId", out var clientId);
 
         if (string.IsNullOrEmpty(tenantId) || string.IsNullOrEmpty(clientId))
         {
@@ -302,10 +301,8 @@ public class ReauthenticateAccountCommand : AsyncCommand<ReauthenticateAccountCo
 
     private async Task<int> ReauthenticateJsonOneDriveAccountAsync(string accountId, Dictionary<string, string> providerConfig)
     {
-        if (!providerConfig.TryGetValue("TenantId", out var tenantId))
-            providerConfig.TryGetValue("tenantId", out tenantId);
-        if (!providerConfig.TryGetValue("ClientId", out var clientId))
-            providerConfig.TryGetValue("clientId", out clientId);
+        providerConfig.TryGetValue("tenantId", out var tenantId);
+        providerConfig.TryGetValue("clientId", out var clientId);
 
         if (string.IsNullOrEmpty(tenantId) || string.IsNullOrEmpty(clientId))
         {
@@ -350,11 +347,8 @@ public class ReauthenticateAccountCommand : AsyncCommand<ReauthenticateAccountCo
 
     private async Task<int> ReauthenticateGoogleAccountAsync(string accountId, Dictionary<string, string> providerConfig)
     {
-        // Try both PascalCase and camelCase for config keys
-        if (!providerConfig.TryGetValue("ClientId", out var clientId))
-            providerConfig.TryGetValue("clientId", out clientId);
-        if (!providerConfig.TryGetValue("ClientSecret", out var clientSecret))
-            providerConfig.TryGetValue("clientSecret", out clientSecret);
+        providerConfig.TryGetValue("clientId", out var clientId);
+        providerConfig.TryGetValue("clientSecret", out var clientSecret);
 
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
         {

--- a/src/CalendarMcp.Core/Models/AccountInfo.cs
+++ b/src/CalendarMcp.Core/Models/AccountInfo.cs
@@ -36,7 +36,20 @@ public class AccountInfo
     public int Priority { get; init; } = 0;
     
     /// <summary>
-    /// Provider-specific configuration (tenant ID, client ID, etc.)
+    /// Provider-specific configuration (tenant ID, client ID, etc.).
+    /// Keys are compared case-insensitively so callers can use either camelCase
+    /// or PascalCase without coordination.
     /// </summary>
-    public Dictionary<string, string> ProviderConfig { get; init; } = new();
+    public Dictionary<string, string> ProviderConfig
+    {
+        get => _providerConfig;
+        init => _providerConfig = NormalizeComparer(value);
+    }
+
+    private Dictionary<string, string> _providerConfig = new(StringComparer.OrdinalIgnoreCase);
+
+    private static Dictionary<string, string> NormalizeComparer(Dictionary<string, string> source) =>
+        ReferenceEquals(source.Comparer, StringComparer.OrdinalIgnoreCase)
+            ? source
+            : new Dictionary<string, string>(source, StringComparer.OrdinalIgnoreCase);
 }

--- a/src/CalendarMcp.Core/Providers/IcsProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/IcsProviderService.cs
@@ -48,8 +48,7 @@ public class IcsProviderService : IIcsProviderService
             return null;
         }
 
-        if (!account.ProviderConfig.TryGetValue("icsUrl", out var icsUrl) &&
-            !account.ProviderConfig.TryGetValue("IcsUrl", out icsUrl))
+        if (!account.ProviderConfig.TryGetValue("icsUrl", out var icsUrl))
         {
             _logger.LogError("Account {AccountId} missing icsUrl in ProviderConfig", accountId);
             return null;
@@ -98,8 +97,7 @@ public class IcsProviderService : IIcsProviderService
 
     private static int GetCacheTtl(AccountInfo account)
     {
-        if (account.ProviderConfig.TryGetValue("cacheTtlMinutes", out var ttlStr) ||
-            account.ProviderConfig.TryGetValue("CacheTtlMinutes", out ttlStr))
+        if (account.ProviderConfig.TryGetValue("cacheTtlMinutes", out var ttlStr))
         {
             if (int.TryParse(ttlStr, out var ttl) && ttl > 0)
                 return ttl;

--- a/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
@@ -169,8 +169,7 @@ public class JsonCalendarProviderService : IJsonCalendarProviderService
         string? refAccountId = null;
         var isReusedCredentials = false;
 
-        if (account.ProviderConfig.TryGetValue("authAccountId", out refAccountId) ||
-            account.ProviderConfig.TryGetValue("AuthAccountId", out refAccountId))
+        if (account.ProviderConfig.TryGetValue("authAccountId", out refAccountId))
         {
             isReusedCredentials = true;
             var refAccount = await _accountRegistry.GetAccountAsync(refAccountId);
@@ -233,8 +232,7 @@ public class JsonCalendarProviderService : IJsonCalendarProviderService
 
     private static int GetCacheTtl(AccountInfo account)
     {
-        if (account.ProviderConfig.TryGetValue("cacheTtlMinutes", out var ttlStr) ||
-            account.ProviderConfig.TryGetValue("CacheTtlMinutes", out ttlStr))
+        if (account.ProviderConfig.TryGetValue("cacheTtlMinutes", out var ttlStr))
         {
             if (int.TryParse(ttlStr, out var ttl) && ttl > 0)
                 return ttl;

--- a/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
@@ -42,11 +42,8 @@ public class OutlookComProviderService : IOutlookComProviderService
             return null;
         }
 
-        // Try both camelCase and PascalCase for config keys
-        if (!account.ProviderConfig.TryGetValue("tenantId", out var tenantId))
-            account.ProviderConfig.TryGetValue("TenantId", out tenantId);
-        if (!account.ProviderConfig.TryGetValue("clientId", out var clientId))
-            account.ProviderConfig.TryGetValue("ClientId", out clientId);
+        account.ProviderConfig.TryGetValue("tenantId", out var tenantId);
+        account.ProviderConfig.TryGetValue("clientId", out var clientId);
 
         if (string.IsNullOrEmpty(tenantId) || string.IsNullOrEmpty(clientId))
         {

--- a/src/CalendarMcp.HttpServer/Admin/DeviceCodeAuthManager.cs
+++ b/src/CalendarMcp.HttpServer/Admin/DeviceCodeAuthManager.cs
@@ -123,8 +123,7 @@ public class DeviceCodeAuthManager
         {
             if (a.Provider is not ("json" or "json-calendar"))
                 return false;
-            if (!a.ProviderConfig.TryGetValue("authAccountId", out var authId) &&
-                !a.ProviderConfig.TryGetValue("AuthAccountId", out authId))
+            if (!a.ProviderConfig.TryGetValue("authAccountId", out var authId))
                 return false;
             return authId == account.Id;
         });

--- a/src/CalendarMcp.Tests/Models/AccountInfoTests.cs
+++ b/src/CalendarMcp.Tests/Models/AccountInfoTests.cs
@@ -1,0 +1,56 @@
+using CalendarMcp.Core.Models;
+
+namespace CalendarMcp.Tests.Models;
+
+[TestClass]
+public class AccountInfoTests
+{
+    [TestMethod]
+    public void ProviderConfig_DefaultDictionary_IsCaseInsensitive()
+    {
+        var account = new AccountInfo
+        {
+            Id = "a",
+            DisplayName = "A",
+            Provider = "google",
+            ProviderConfig = new Dictionary<string, string>
+            {
+                ["ClientId"] = "id",
+                ["ClientSecret"] = "secret"
+            }
+        };
+
+        Assert.IsTrue(account.ProviderConfig.TryGetValue("clientId", out var clientId));
+        Assert.AreEqual("id", clientId);
+        Assert.IsTrue(account.ProviderConfig.TryGetValue("clientSecret", out var clientSecret));
+        Assert.AreEqual("secret", clientSecret);
+    }
+
+    [TestMethod]
+    public void ProviderConfig_AlreadyCaseInsensitive_PreservesInstance()
+    {
+        var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["TenantId"] = "t"
+        };
+
+        var account = new AccountInfo
+        {
+            Id = "a",
+            DisplayName = "A",
+            Provider = "microsoft365",
+            ProviderConfig = source
+        };
+
+        Assert.AreSame(source, account.ProviderConfig);
+    }
+
+    [TestMethod]
+    public void ProviderConfig_DefaultInitializer_IsCaseInsensitive()
+    {
+        var account = new AccountInfo { Id = "a", DisplayName = "A", Provider = "google" };
+        account.ProviderConfig["ClientId"] = "id";
+
+        Assert.IsTrue(account.ProviderConfig.ContainsKey("clientId"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adding a Google account via the admin UI then attempting to authenticate failed with `Account is missing clientId or clientSecret in configuration.` even though both fields were populated. Root cause: the form persisted PascalCase keys (`ClientId`, `ClientSecret`) but the OAuth start endpoint did a case-sensitive lookup on lowercase keys against a default `Dictionary<string, string>`.
- Fixed at the source: `AccountInfo.ProviderConfig` now always uses `StringComparer.OrdinalIgnoreCase` — both the default initializer and the `init` setter (which rebuilds the dict with the right comparer if assigned a case-sensitive one). `AccountConfigurationService` returns case-insensitive dicts when reading from the JSON file too. With the underlying dictionary case-insensitive, the dual-lookup workarounds in `IcsProviderService`, `OutlookComProviderService`, `JsonCalendarProviderService`, `DeviceCodeAuthManager`, and `ReauthenticateAccountCommand` are redundant and have been removed.
- Bumped `VersionPrefix` to 1.1.1 and fixed the Dockerfile to copy `Directory.Build.props` into the build context, so the assembly version (added in #48) actually propagates into the container — previously it was silently 0.0.0.0 inside the image.

## Test plan

- [x] `dotnet test` — 201/201 passing, including 3 new `AccountInfoTests` covering the case-insensitive contract
- [x] Built and pushed `rockylhotka/calendar-mcp-http:1.1.1` / `:latest`
- [x] Verified `1.1.1.0` assembly version embedded in the image
- [x] Deployed to k8s (`calendar-mcp` namespace) and confirmed the Google OAuth start flow now works for accounts originally created via the admin UI — no need to delete and recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)