### PR TITLE
Add IMAP/SMTP provider for unattended mailboxes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calendar & Email MCP Server
 
-A Model Context Protocol (MCP) server that gives AI assistants access to email, calendar, and contact data across multiple accounts — Microsoft 365, Outlook.com, Google Workspace, ICS feeds, and JSON calendar files.
+A Model Context Protocol (MCP) server that gives AI assistants access to email, calendar, and contact data across multiple accounts — Microsoft 365, Outlook.com, Google Workspace, IMAP/SMTP mailboxes, ICS feeds, and JSON calendar files.
 
 ## Overview
 
@@ -13,6 +13,7 @@ Calendar-MCP aggregates email, calendar, and contact information from multiple p
 | Microsoft 365 | Yes | Yes | Yes | OAuth 2.0 (MSAL) |
 | Outlook.com | Yes | Yes | Yes | OAuth 2.0 (MSAL) |
 | Google Workspace / Gmail | Yes | Yes | Yes | OAuth 2.0 |
+| IMAP/SMTP | Yes | -- | -- | Username + app password (encrypted at rest) |
 | ICS Calendar Feeds | -- | Read-only | -- | None (public URLs) |
 | JSON Calendar Files | -- | Read-only | -- | None (local files) |
 

--- a/docs/IMAP-SETUP.md
+++ b/docs/IMAP-SETUP.md
@@ -1,0 +1,118 @@
+# IMAP/SMTP Setup Guide
+
+This guide walks through configuring an IMAP/SMTP mailbox in calendar-mcp. The IMAP provider is **email-only** — calendar and contact tools throw `NotSupportedException` for these accounts. Use it when:
+
+- You need an unattended mailbox on a consumer Gmail account where OAuth's 7-day refresh-token expiry would otherwise force weekly re-auth.
+- You want to attach a non-Microsoft, non-Google mailbox (Fastmail, Apple iCloud, a self-hosted IMAP server) without writing a new provider.
+
+## Table of contents
+
+- [Gmail with an app password](#gmail-with-an-app-password)
+- [Other IMAP/SMTP hosts](#other-imapsmtp-hosts)
+- [Configuration via the admin UI](#configuration-via-the-admin-ui)
+- [Configuration via JSON](#configuration-via-json)
+- [Folder semantics](#folder-semantics)
+- [Email IDs](#email-ids)
+- [Password storage](#password-storage)
+- [Troubleshooting](#troubleshooting)
+
+## Gmail with an app password
+
+Gmail requires 2-Step Verification before you can mint an app password.
+
+1. Sign in to the Google account you want the bot to use.
+2. Enable 2-Step Verification at <https://myaccount.google.com/security>.
+3. Generate an app password at <https://myaccount.google.com/apppasswords>.
+   - "App" — pick "Mail" (or "Other" and label it `calendar-mcp`).
+   - Copy the 16-character password Google shows you. It won't be shown again.
+4. Use the address as `username` and the 16-character app password as `password` in calendar-mcp. The defaults (`imap.gmail.com:993`, `smtp.gmail.com:587`, `[Gmail]/Sent Mail`, `[Gmail]/Trash`) are correct out of the box.
+
+App passwords don't expire and aren't subject to the unverified-app refresh-token treadmill — the bot stays authenticated indefinitely until you revoke the app password.
+
+## Other IMAP/SMTP hosts
+
+Any host that speaks standard IMAP and SMTP works. Common values:
+
+| Host        | IMAP                  | SMTP                   | Sent folder           | Trash folder    |
+|-------------|-----------------------|------------------------|------------------------|-----------------|
+| Gmail       | `imap.gmail.com:993`  | `smtp.gmail.com:587`   | `[Gmail]/Sent Mail`    | `[Gmail]/Trash` |
+| Fastmail    | `imap.fastmail.com:993` | `smtp.fastmail.com:465` | `Sent`               | `Trash`         |
+| iCloud      | `imap.mail.me.com:993` | `smtp.mail.me.com:587` | `Sent Messages`       | `Deleted Messages` |
+| Yahoo       | `imap.mail.yahoo.com:993` | `smtp.mail.yahoo.com:587` | `Sent`            | `Trash`         |
+
+Most providers also require an app-specific password rather than your main account password. Check the provider's docs.
+
+## Configuration via the admin UI
+
+1. Open the admin UI (e.g. `https://<your-host>/admin/ui/accounts/add`).
+2. Pick **IMAP/SMTP** from the provider grid.
+3. Fill in:
+   - **Account ID** — slug-friendly identifier (e.g. `rockbot-imap`).
+   - **Display Name** — human-readable label.
+   - **Username** — the email address.
+   - **Password** — the app password.
+4. Hosts and ports default to Gmail; override for other providers.
+5. Folder names live under **Advanced — folder names**; defaults match Gmail.
+6. **Save**.
+
+The admin UI encrypts the password before persisting, so the value in `appsettings.json` will be prefixed with `ENC:`.
+
+## Configuration via JSON
+
+Add an entry to `CalendarMcp.Accounts` in `appsettings.json`:
+
+```json
+{
+  "Id": "rockbot-imap",
+  "DisplayName": "Rockbot Mailbox",
+  "Provider": "imap",
+  "Domains": ["gmail.com"],
+  "Enabled": true,
+  "Priority": 0,
+  "ProviderConfig": {
+    "imapHost": "imap.gmail.com",
+    "imapPort": "993",
+    "smtpHost": "smtp.gmail.com",
+    "smtpPort": "587",
+    "username": "rockbot@gmail.com",
+    "password": "<app password — see below>",
+    "inboxFolder": "INBOX",
+    "sentFolder": "[Gmail]/Sent Mail",
+    "trashFolder": "[Gmail]/Trash"
+  }
+}
+```
+
+You can paste the password as plaintext if you must — calendar-mcp will read it (no `ENC:` prefix means "treat as plaintext"). The next time the entry is saved through the admin UI, it will be re-saved encrypted. Encrypting it ahead of time requires running through the UI; there is no CLI tool for offline encryption today.
+
+## Folder semantics
+
+- `inboxFolder` is the folder `get_emails` reads from when no folder is specified. Defaults to `INBOX`.
+- `sentFolder` is where calendar-mcp APPENDs a copy of every message you send via `send_email`. APPEND failure is non-fatal — the message still goes out — but you'll see a warning in logs.
+- `trashFolder` is where `delete_email` moves messages. The provider does **not** EXPUNGE — that matches Gmail and most modern clients, and lets users recover messages from Trash.
+
+If your provider doesn't have a single canonical Sent or Trash folder name, set the values explicitly.
+
+## Email IDs
+
+IMAP messages are identified by `(folder, UIDVALIDITY, UID)`. calendar-mcp encodes that as `folder/uidvalidity/uid` — for example `INBOX/1234567890/4567` or `[Gmail]/Trash/1234567890/42`. Internal slashes inside the folder name are preserved.
+
+When the underlying folder gets recreated (rare — it changes UIDVALIDITY), previously-issued IDs become invalid. The provider detects this and returns a clear error rather than silently fetching the wrong message.
+
+## Password storage
+
+Passwords are encrypted at rest using ASP.NET DataProtection. Stored values look like `ENC:CfDJ8...`. The keystore lives at `<data-dir>/keys/` — `/app/data/keys/` in the k8s deployment, `%LOCALAPPDATA%\CalendarMcp\keys\` on Windows. Back up the data directory and you keep both the encrypted secrets and the keys to read them.
+
+See [`security.md`](security.md#password-encryption-at-rest-imap-accounts) for the threat model.
+
+## Troubleshooting
+
+**`AuthenticationException` on connect.** Double-check that 2-Step Verification is enabled on the Google account before generating the app password. Without it, app passwords aren't available and your account password won't work for IMAP.
+
+**`AppendAsync` fails with "folder not found"** for the Sent or Trash folder. The default folder names (`[Gmail]/Sent Mail`, `[Gmail]/Trash`) are Gmail-specific. Check the table above or your provider's docs and edit the Advanced settings on the account.
+
+**Sent messages don't appear in the user's Sent box.** Either the `sentFolder` is wrong (most likely), or the message went out but the APPEND silently failed — check the server log for a warning starting with `Failed to APPEND sent message`.
+
+**`UIDVALIDITY mismatch` warning**, message returns `null`. The folder was recreated since the ID was issued; re-list the folder to get current IDs.
+
+**Calendar/contact tools fail with `NotSupportedException`.** Expected — the IMAP provider is email-only. `list_accounts` advertises only the `email` capability, so well-behaved callers won't try.

--- a/docs/IMPLEMENTATION-STATUS.md
+++ b/docs/IMPLEMENTATION-STATUS.md
@@ -62,11 +62,13 @@ src/
 - **IProviderServiceFactory**: Factory for resolving providers by account type
 - **IAccountRegistry**: Account configuration and lookup
 
-### ✅ Provider Implementations (Stubs)
-All three providers implemented as stubs with logging:
+### ✅ Provider Implementations
 - **M365ProviderService**: Microsoft 365 / Outlook organizational accounts
-- **GoogleProviderService**: Google Workspace / Gmail accounts  
+- **GoogleProviderService**: Google Workspace / Gmail accounts
 - **OutlookComProviderService**: Outlook.com personal Microsoft accounts
+- **IcsProviderService**: Read-only ICS feed calendar provider
+- **JsonCalendarProviderService**: Local or OneDrive JSON file calendar provider
+- **ImapProviderService**: IMAP/SMTP mailbox provider (email-only). Password encrypted at rest via ASP.NET DataProtection.
 - **ProviderServiceFactory**: Routes requests to correct provider
 - **AccountRegistry**: Loads and manages account configuration
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -232,6 +232,17 @@ Tool execution:
 ✅ No shared authentication state between accounts
 ```
 
+## IMAP/SMTP Authentication
+
+The `imap` provider does not use OAuth. Each account stores a username and a password (typically an app password from the mail provider) directly in its `ProviderConfig`. The password is encrypted at rest using ASP.NET DataProtection — the persisted value carries an `ENC:` prefix and is unprotected on demand by the provider.
+
+This is the right choice when:
+
+- You need an unattended bot mailbox on a consumer Gmail account, where OAuth refresh tokens expire weekly while the app sits in Testing publishing status.
+- You want to attach a non-Microsoft, non-Google mailbox (Fastmail, Apple iCloud, custom IMAP server, etc.) without writing a new provider.
+
+Setup walkthrough including the Gmail-specific app-password steps lives in [`IMAP-SETUP.md`](IMAP-SETUP.md). For the encryption-at-rest details and threat model, see [`security.md`](security.md#password-encryption-at-rest-imap-accounts).
+
 ## Security Best Practices
 
 1. **Credential Storage**: System-level encryption (DPAPI, Keychain)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,6 +239,46 @@ set CALENDAR_MCP_CONFIG=C:\MyConfig\my-calendar-config.json
 
 **Note**: Outlook.com uses 'common' tenant automatically (no tenantId needed).
 
+### IMAP/SMTP Accounts
+
+```json
+{
+  "Id": "rockbot-imap",
+  "DisplayName": "Rockbot Mailbox",
+  "Provider": "imap",
+  "Domains": ["gmail.com"],
+  "ProviderConfig": {
+    "imapHost": "imap.gmail.com",
+    "imapPort": "993",
+    "smtpHost": "smtp.gmail.com",
+    "smtpPort": "587",
+    "username": "rockbot@gmail.com",
+    "password": "ENC:CfDJ8...",
+    "inboxFolder": "INBOX",
+    "sentFolder": "[Gmail]/Sent Mail",
+    "trashFolder": "[Gmail]/Trash"
+  }
+}
+```
+
+**Required ProviderConfig keys**: `imapHost`, `smtpHost`, `username`, `password`.
+
+**Defaults** (Gmail-tuned but fully overridable for any IMAP host):
+
+| Key            | Default              |
+|----------------|----------------------|
+| `imapPort`     | `993`                |
+| `smtpPort`     | `587` (STARTTLS)     |
+| `inboxFolder`  | `INBOX`              |
+| `sentFolder`   | `[Gmail]/Sent Mail`  |
+| `trashFolder`  | `[Gmail]/Trash`      |
+
+**Password storage**: `password` is encrypted at rest via ASP.NET DataProtection — values written by the admin UI or CLI are stored with an `ENC:` prefix and the keystore lives under the data directory (see `docs/security.md`). Plaintext values without the prefix are still readable, so manually-edited entries continue to work.
+
+**Capabilities**: Email-only (read/write). Calendar and contact tools fail with a clear `NotSupportedException` for IMAP accounts; pick a different account for those operations.
+
+For setup walkthrough including Gmail app passwords, see `docs/IMAP-SETUP.md`.
+
 ## Router Configuration
 
 ### Ollama (Local)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -192,6 +192,50 @@ public class OutlookComProviderService : IOutlookComProviderService
 ### Validation Status
 ✅ Validated through OutlookComPersonal spike
 
+## IImapProviderService
+
+Direct IMAP/SMTP integration via [MailKit](https://github.com/jstedfast/MailKit) for any mailbox that speaks the standard protocols. **Email-only** — calendar and contact methods throw `NotSupportedException`. Designed for unattended bot mailboxes where OAuth's 7-day refresh-token expiry on consumer accounts is a non-starter.
+
+### SDK & Dependencies
+- **MailKit** (v4.x) — IMAP/SMTP client + MIME parser
+
+### Account Management
+- **One provider service instance manages multiple IMAP accounts** with strict per-account credential isolation.
+- Each `ImapClient` / `SmtpClient` is opened, used, and disposed per call. No connection pooling in the initial implementation.
+
+### Configuration
+
+Provider id: `imap` (alias `imap-smtp`).
+
+| Key            | Required | Default              | Notes                                                                                  |
+|----------------|----------|----------------------|----------------------------------------------------------------------------------------|
+| `imapHost`     | yes      | `imap.gmail.com`     | Form pre-fills the default; user can override for any host.                            |
+| `imapPort`     | no       | `993`                |                                                                                        |
+| `smtpHost`     | yes      | `smtp.gmail.com`     |                                                                                        |
+| `smtpPort`     | no       | `587`                | STARTTLS on 587, implicit TLS on 465 — `SecureSocketOptions.Auto` picks per port.      |
+| `username`     | yes      | —                    | Typically the email address.                                                           |
+| `password`     | yes      | —                    | App password / IMAP password. Stored encrypted via ASP.NET DataProtection.             |
+| `inboxFolder`  | no       | `INBOX`              | Default folder for `GetEmailsAsync`.                                                   |
+| `sentFolder`   | no       | `[Gmail]/Sent Mail`  | After SMTP send, the message is APPENDed here.                                         |
+| `trashFolder`  | no       | `[Gmail]/Trash`      | `DeleteEmailAsync` moves to this folder rather than expunging.                         |
+
+Defaults are Gmail-tuned but **not** hard-coded in the provider — every value can be overridden per account, so the provider works for Fastmail, Apple iCloud, custom servers, etc.
+
+### Email ID format
+
+IMAP messages are identified by `(folder, UIDVALIDITY, UID)`. The provider encodes IDs as `folder/uidvalidity/uid` (e.g. `INBOX/1234567890/4567`). Folder names containing literal slashes (Gmail's `[Gmail]/Trash` etc.) are preserved — parsing splits on the trailing two slashes only.
+
+### Capabilities
+- Email: read, search, send, delete, mark read/unread, move (full read/write)
+- Calendar / Contacts: throw `NotSupportedException`
+
+### Authentication
+- Username + password / app password — see `docs/IMAP-SETUP.md` for the Gmail walkthrough.
+- Password is encrypted at rest using ASP.NET DataProtection — see `docs/security.md`.
+
+### Validation Status
+🆕 New in this release. Validated end-to-end against Gmail using an app password.
+
 ## Provider Service Factory
 
 Resolves the correct provider service based on account type.

--- a/docs/security.md
+++ b/docs/security.md
@@ -131,11 +131,30 @@ export CALENDAR_MCP_Accounts__0__Configuration__ClientSecret="GOCSPX-..."
 # - HashiCorp Vault
 ```
 
+### Password Encryption At Rest (IMAP Accounts)
+
+The IMAP/SMTP provider stores its `password` field encrypted via ASP.NET DataProtection. Values written by the admin UI or any future CLI command land in `appsettings.json` as a string starting with the `ENC:` prefix followed by the protected blob.
+
+**Key persistence**:
+- Keys are persisted to `<data-dir>/keys/` (e.g. `/app/data/keys/` in k8s, `%LOCALAPPDATA%\CalendarMcp\keys\` locally).
+- The same data directory holds `appsettings.json`, so backup/restore of the data volume covers both — but lose the keystore and you lose the ability to decrypt previously-stored passwords.
+- All hosts (`HttpServer`, `StdioServer`, anything else calling `AddCalendarMcpCore`) share the same keystore and can encrypt or decrypt values written by another host.
+
+**Threat model**:
+- ✅ Protects against config-volume-only leaks (someone reads `appsettings.json` but not the keystore).
+- ✅ Reduces the chance an accidental log dump, screenshot, or chat paste contains a usable password.
+- ✅ Stops naive `grep` for the password value.
+- ❌ Does **not** protect against full-data-directory compromise — the keystore is right next to the encrypted data. This is intentional: a separate KMS or HSM would be a different feature.
+
+**Compatibility**:
+- A stored value without the `ENC:` prefix is treated as plaintext and returned as-is. This means manually-edited entries continue to work, and a future migration that re-saves them through the UI will encrypt them.
+
 ### File Permissions
 
 **appsettings.json**:
 - Contains account metadata (IDs, domains, priorities)
-- Does NOT contain secrets or tokens
+- IMAP passwords stored encrypted (with `ENC:` prefix) — see above
+- Other secrets and tokens are not stored here
 - Can be committed to source control (with secrets externalized)
 
 **Recommended permissions**:

--- a/src/CalendarMcp.Auth/AccountValidation.cs
+++ b/src/CalendarMcp.Auth/AccountValidation.cs
@@ -71,7 +71,7 @@ public static partial class AccountValidation
     /// <summary>Known provider types.</summary>
     public static readonly IReadOnlySet<string> KnownProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
-        "microsoft365", "outlook.com", "google", "ics", "json"
+        "microsoft365", "outlook.com", "google", "ics", "json", "imap"
     };
 
     /// <summary>
@@ -117,6 +117,7 @@ public static partial class AccountValidation
             "google" => ValidateRequiredKeys(config, "ClientId", "ClientSecret"),
             "ics" => ValidateIcsConfig(config),
             "json" => ValidateJsonConfig(config),
+            "imap" => ValidateRequiredKeys(config, "imapHost", "smtpHost", "username", "password"),
             _ => (false, $"Unknown provider '{provider}'.")
         };
     }

--- a/src/CalendarMcp.Auth/CalendarMcp.Auth.csproj
+++ b/src/CalendarMcp.Auth/CalendarMcp.Auth.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CalendarMcp.Cli/CalendarMcp.Cli.csproj
+++ b/src/CalendarMcp.Cli/CalendarMcp.Cli.csproj
@@ -13,11 +13,11 @@
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/CalendarMcp.Core/CalendarMcp.Core.csproj
+++ b/src/CalendarMcp.Core/CalendarMcp.Core.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Microsoft.Graph" Version="5.68.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.2" />
@@ -20,7 +20,10 @@
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="Google.Apis.PeopleService.v1" Version="1.69.0.3785" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/CalendarMcp.Core/Configuration/ConfigurationPaths.cs
+++ b/src/CalendarMcp.Core/Configuration/ConfigurationPaths.cs
@@ -78,6 +78,16 @@ public static class ConfigurationPaths
     }
 
     /// <summary>
+    /// Gets the directory used by ASP.NET DataProtection to persist its key ring.
+    /// Lives under the data directory so it follows the existing CALENDAR_MCP_CONFIG override
+    /// and is preserved by the same volume mount that holds appsettings.json.
+    /// </summary>
+    public static string GetDataProtectionKeysDirectory()
+    {
+        return Path.Combine(GetDataDirectory(), "keys");
+    }
+
+    /// <summary>
     /// Ensures the data directory exists.
     /// </summary>
     public static void EnsureDataDirectoryExists()

--- a/src/CalendarMcp.Core/Configuration/DataProtectionExtensions.cs
+++ b/src/CalendarMcp.Core/Configuration/DataProtectionExtensions.cs
@@ -1,0 +1,33 @@
+using CalendarMcp.Core.Security;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CalendarMcp.Core.Configuration;
+
+/// <summary>
+/// Registers ASP.NET DataProtection with a keystore persisted under the
+/// Calendar MCP data directory. Each host (HttpServer, StdioServer, Cli)
+/// calls this so any host can encrypt or decrypt values produced by another,
+/// as long as they share the same data directory (which is the contract
+/// established by <see cref="ConfigurationPaths.GetDataDirectory"/>).
+/// </summary>
+public static class DataProtectionExtensions
+{
+    /// <summary>Application name passed to DataProtection. Constant across hosts.</summary>
+    public const string ApplicationName = "CalendarMcp";
+
+    public static IServiceCollection AddCalendarMcpDataProtection(this IServiceCollection services)
+    {
+        var keysDir = ConfigurationPaths.GetDataProtectionKeysDirectory();
+        Directory.CreateDirectory(keysDir);
+
+        services
+            .AddDataProtection()
+            .SetApplicationName(ApplicationName)
+            .PersistKeysToFileSystem(new DirectoryInfo(keysDir));
+
+        services.AddSingleton<PasswordProtector>();
+
+        return services;
+    }
+}

--- a/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
@@ -27,7 +27,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IOutlookComProviderService, OutlookComProviderService>();
         services.AddSingleton<IIcsProviderService, IcsProviderService>();
         services.AddSingleton<IJsonCalendarProviderService, JsonCalendarProviderService>();
+        services.AddSingleton<IImapProviderService, ImapProviderService>();
         services.AddSingleton<IProviderServiceFactory, ProviderServiceFactory>();
+
+        // DataProtection + PasswordProtector for at-rest encryption of provider passwords
+        services.AddCalendarMcpDataProtection();
 
         // Register HttpClient for ICS provider
         services.AddHttpClient("IcsProvider");

--- a/src/CalendarMcp.Core/Providers/ImapProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/ImapProviderService.cs
@@ -1,0 +1,542 @@
+using CalendarMcp.Core.Models;
+using CalendarMcp.Core.Security;
+using CalendarMcp.Core.Services;
+using CalendarMcp.Core.Utilities;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Net.Smtp;
+using MailKit.Search;
+using MailKit.Security;
+using Microsoft.Extensions.Logging;
+using MimeKit;
+using MimeKit.Text;
+
+namespace CalendarMcp.Core.Providers;
+
+/// <summary>
+/// Provider service for any IMAP/SMTP-accessible mailbox. Email-only — calendar and
+/// contact methods throw <see cref="NotSupportedException"/>. Defaults are tuned for
+/// Gmail (host names, sent/trash folders) but every value can be overridden per
+/// account, so the provider works for any IMAP host.
+/// </summary>
+public class ImapProviderService : IImapProviderService
+{
+    public const string DefaultImapHost = "imap.gmail.com";
+    public const int DefaultImapPort = 993;
+    public const string DefaultSmtpHost = "smtp.gmail.com";
+    public const int DefaultSmtpPort = 587;
+    public const string DefaultInbox = "INBOX";
+    public const string DefaultSent = "[Gmail]/Sent Mail";
+    public const string DefaultTrash = "[Gmail]/Trash";
+
+    private const string ProviderName = "imap";
+
+    private const MessageSummaryItems EnvelopeItems =
+        MessageSummaryItems.Envelope |
+        MessageSummaryItems.Flags |
+        MessageSummaryItems.UniqueId |
+        MessageSummaryItems.BodyStructure |
+        MessageSummaryItems.InternalDate |
+        MessageSummaryItems.Headers;
+
+    private readonly IAccountRegistry _accountRegistry;
+    private readonly PasswordProtector _passwordProtector;
+    private readonly ILogger<ImapProviderService> _logger;
+
+    public ImapProviderService(
+        IAccountRegistry accountRegistry,
+        PasswordProtector passwordProtector,
+        ILogger<ImapProviderService> logger)
+    {
+        _accountRegistry = accountRegistry;
+        _passwordProtector = passwordProtector;
+        _logger = logger;
+    }
+
+    // ── ID encoding ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Encodes a stable, portable email ID as <c>folder/uidvalidity/uid</c>. Folder names
+    /// containing literal slashes (Gmail uses <c>[Gmail]/Trash</c> etc.) are preserved as-is —
+    /// parsing splits on the last two slashes so internal slashes inside the folder name
+    /// don't confuse it.
+    /// </summary>
+    public static string FormatEmailId(string folder, uint uidValidity, uint uid) =>
+        $"{folder}/{uidValidity}/{uid}";
+
+    /// <summary>
+    /// Parses an ID created by <see cref="FormatEmailId"/>. Throws if the format is invalid —
+    /// callers must surface a user-facing error rather than silently misinterpret.
+    /// </summary>
+    public static (string Folder, uint UidValidity, uint Uid) ParseEmailId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("Email ID is required.", nameof(id));
+
+        var lastSlash = id.LastIndexOf('/');
+        if (lastSlash <= 0)
+            throw new FormatException(
+                $"Email ID '{id}' is not in IMAP format. Expected '<folder>/<uidvalidity>/<uid>'.");
+
+        var secondLastSlash = id.LastIndexOf('/', lastSlash - 1);
+        if (secondLastSlash <= 0)
+            throw new FormatException(
+                $"Email ID '{id}' is not in IMAP format. Expected '<folder>/<uidvalidity>/<uid>'.");
+
+        var folder = id[..secondLastSlash];
+        if (!uint.TryParse(id[(secondLastSlash + 1)..lastSlash], out var uidValidity) ||
+            !uint.TryParse(id[(lastSlash + 1)..], out var uid))
+        {
+            throw new FormatException(
+                $"Email ID '{id}' is not in IMAP format. UID validity and UID must be unsigned integers.");
+        }
+
+        return (folder, uidValidity, uid);
+    }
+
+    // ── Account configuration ────────────────────────────────────────
+
+    private async Task<ImapAccountConfig> ResolveConfigAsync(string accountId)
+    {
+        var account = await _accountRegistry.GetAccountAsync(accountId)
+            ?? throw new InvalidOperationException($"Account '{accountId}' not found in registry.");
+
+        var pc = account.ProviderConfig;
+
+        var imapHost = Get(pc, "imapHost", DefaultImapHost);
+        var smtpHost = Get(pc, "smtpHost", DefaultSmtpHost);
+        var username = Get(pc, "username", "");
+        var storedPassword = Get(pc, "password", "");
+
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(storedPassword))
+            throw new InvalidOperationException(
+                $"Account '{accountId}' is missing username or password in providerConfig.");
+
+        return new ImapAccountConfig(
+            AccountId: accountId,
+            ImapHost: imapHost,
+            ImapPort: GetInt(pc, "imapPort", DefaultImapPort),
+            SmtpHost: smtpHost,
+            SmtpPort: GetInt(pc, "smtpPort", DefaultSmtpPort),
+            Username: username,
+            Password: _passwordProtector.Unprotect(storedPassword),
+            InboxFolder: Get(pc, "inboxFolder", DefaultInbox),
+            SentFolder: Get(pc, "sentFolder", DefaultSent),
+            TrashFolder: Get(pc, "trashFolder", DefaultTrash));
+
+        static string Get(IDictionary<string, string> d, string key, string fallback) =>
+            d.TryGetValue(key, out var v) && !string.IsNullOrWhiteSpace(v) ? v : fallback;
+
+        static int GetInt(IDictionary<string, string> d, string key, int fallback) =>
+            d.TryGetValue(key, out var v) && int.TryParse(v, out var n) && n > 0 ? n : fallback;
+    }
+
+    private async Task<ImapClient> OpenImapAsync(ImapAccountConfig cfg, CancellationToken ct)
+    {
+        var client = new ImapClient();
+        try
+        {
+            await client.ConnectAsync(cfg.ImapHost, cfg.ImapPort, SecureSocketOptions.Auto, ct);
+            await client.AuthenticateAsync(cfg.Username, cfg.Password, ct);
+            return client;
+        }
+        catch
+        {
+            client.Dispose();
+            throw;
+        }
+    }
+
+    private async Task<SmtpClient> OpenSmtpAsync(ImapAccountConfig cfg, CancellationToken ct)
+    {
+        var client = new SmtpClient();
+        try
+        {
+            await client.ConnectAsync(cfg.SmtpHost, cfg.SmtpPort, SecureSocketOptions.Auto, ct);
+            await client.AuthenticateAsync(cfg.Username, cfg.Password, ct);
+            return client;
+        }
+        catch
+        {
+            client.Dispose();
+            throw;
+        }
+    }
+
+    private static async Task<IMailFolder> OpenFolderAsync(
+        ImapClient client, string folderName, FolderAccess access, CancellationToken ct)
+    {
+        var folder = string.Equals(folderName, "INBOX", StringComparison.OrdinalIgnoreCase)
+            ? client.Inbox
+            : await client.GetFolderAsync(folderName, ct);
+
+        if (folder is null)
+            throw new InvalidOperationException($"IMAP folder '{folderName}' not found.");
+
+        await folder.OpenAsync(access, ct);
+        return folder;
+    }
+
+    // ── Email operations ─────────────────────────────────────────────
+
+    public async Task<IEnumerable<EmailMessage>> GetEmailsAsync(
+        string accountId, int count = 20, bool unreadOnly = false, CancellationToken cancellationToken = default)
+    {
+        var cfg = await ResolveConfigAsync(accountId);
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, cfg.InboxFolder, FolderAccess.ReadOnly, cancellationToken);
+
+        IList<UniqueId> uids;
+        if (unreadOnly)
+        {
+            uids = await folder.SearchAsync(SearchQuery.NotSeen, cancellationToken);
+        }
+        else
+        {
+            uids = (await folder.SearchAsync(SearchQuery.All, cancellationToken)).ToList();
+        }
+
+        var newest = uids.OrderByDescending(u => u.Id).Take(count).ToList();
+        if (newest.Count == 0)
+            return [];
+
+        var summaries = await folder.FetchAsync(newest, EnvelopeItems, cancellationToken);
+
+        return summaries
+            .OrderByDescending(s => s.InternalDate ?? s.Date)
+            .Select(s => SummaryToEmail(s, cfg.InboxFolder, folder.UidValidity, accountId))
+            .ToList();
+    }
+
+    public async Task<IEnumerable<EmailMessage>> SearchEmailsAsync(
+        string accountId, string query, int count = 20,
+        DateTime? fromDate = null, DateTime? toDate = null,
+        CancellationToken cancellationToken = default)
+    {
+        var cfg = await ResolveConfigAsync(accountId);
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, cfg.InboxFolder, FolderAccess.ReadOnly, cancellationToken);
+
+        SearchQuery search = string.IsNullOrWhiteSpace(query)
+            ? SearchQuery.All
+            : SearchQuery.SubjectContains(query)
+                .Or(SearchQuery.BodyContains(query))
+                .Or(SearchQuery.FromContains(query));
+
+        if (fromDate.HasValue)
+            search = search.And(SearchQuery.DeliveredAfter(fromDate.Value));
+        if (toDate.HasValue)
+            search = search.And(SearchQuery.DeliveredBefore(toDate.Value));
+
+        var uids = (await folder.SearchAsync(search, cancellationToken))
+            .OrderByDescending(u => u.Id)
+            .Take(count)
+            .ToList();
+
+        if (uids.Count == 0)
+            return [];
+
+        var summaries = await folder.FetchAsync(uids, EnvelopeItems, cancellationToken);
+
+        return summaries
+            .OrderByDescending(s => s.InternalDate ?? s.Date)
+            .Select(s => SummaryToEmail(s, cfg.InboxFolder, folder.UidValidity, accountId))
+            .ToList();
+    }
+
+    public async Task<EmailMessage?> GetEmailDetailsAsync(
+        string accountId, string emailId, CancellationToken cancellationToken = default)
+    {
+        var (folderName, uidValidity, uid) = ParseEmailId(emailId);
+        var cfg = await ResolveConfigAsync(accountId);
+
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, folderName, FolderAccess.ReadOnly, cancellationToken);
+
+        if (folder.UidValidity != uidValidity)
+        {
+            _logger.LogWarning(
+                "UIDVALIDITY mismatch for {AccountId} folder {Folder}: id={Stored}, current={Current}. Message no longer addressable.",
+                accountId, folderName, uidValidity, folder.UidValidity);
+            return null;
+        }
+
+        var message = await folder.GetMessageAsync(new UniqueId(uid), cancellationToken);
+        if (message is null) return null;
+
+        var summary = (await folder.FetchAsync(new[] { new UniqueId(uid) }, EnvelopeItems, cancellationToken))
+            .FirstOrDefault();
+        var isRead = summary?.Flags?.HasFlag(MessageFlags.Seen) ?? true;
+
+        return MessageToEmail(message, folderName, uidValidity, uid, accountId, isRead);
+    }
+
+    public async Task<string> SendEmailAsync(
+        string accountId, string to, string subject, string body,
+        string bodyFormat = "html", List<string>? cc = null,
+        CancellationToken cancellationToken = default)
+    {
+        var cfg = await ResolveConfigAsync(accountId);
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse(cfg.Username));
+        foreach (var addr in SplitAddresses(to))
+            message.To.Add(MailboxAddress.Parse(addr));
+        if (cc is { Count: > 0 })
+        {
+            foreach (var addr in cc)
+                message.Cc.Add(MailboxAddress.Parse(addr));
+        }
+        message.Subject = subject;
+        message.Body = new TextPart(bodyFormat?.Equals("text", StringComparison.OrdinalIgnoreCase) == true
+            ? TextFormat.Plain
+            : TextFormat.Html)
+        { Text = body };
+
+        using (var smtp = await OpenSmtpAsync(cfg, cancellationToken))
+        {
+            await smtp.SendAsync(message, cancellationToken);
+            await smtp.DisconnectAsync(true, cancellationToken);
+        }
+
+        // APPEND to sent folder so the message shows up in the user's Sent box.
+        // Failure here is non-fatal — the message did go out.
+        try
+        {
+            using var imap = await OpenImapAsync(cfg, cancellationToken);
+            var sent = await imap.GetFolderAsync(cfg.SentFolder, cancellationToken);
+            await sent.OpenAsync(FolderAccess.ReadWrite, cancellationToken);
+            await sent.AppendAsync(message, MessageFlags.Seen, DateTimeOffset.Now, cancellationToken);
+            await imap.DisconnectAsync(true, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to APPEND sent message to {Folder} for account {AccountId}; message was still delivered.",
+                cfg.SentFolder, accountId);
+        }
+
+        return message.MessageId ?? string.Empty;
+    }
+
+    public async Task DeleteEmailAsync(
+        string accountId, string emailId, CancellationToken cancellationToken = default)
+    {
+        var (folderName, uidValidity, uid) = ParseEmailId(emailId);
+        var cfg = await ResolveConfigAsync(accountId);
+
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, folderName, FolderAccess.ReadWrite, cancellationToken);
+        EnsureUidValidity(folder, uidValidity, accountId, folderName);
+
+        var trash = await client.GetFolderAsync(cfg.TrashFolder, cancellationToken);
+        await folder.MoveToAsync(new[] { new UniqueId(uid) }, trash, cancellationToken);
+    }
+
+    public async Task MarkEmailAsReadAsync(
+        string accountId, string emailId, bool isRead, CancellationToken cancellationToken = default)
+    {
+        var (folderName, uidValidity, uid) = ParseEmailId(emailId);
+        var cfg = await ResolveConfigAsync(accountId);
+
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, folderName, FolderAccess.ReadWrite, cancellationToken);
+        EnsureUidValidity(folder, uidValidity, accountId, folderName);
+
+        var ids = new[] { new UniqueId(uid) };
+        if (isRead)
+            await folder.AddFlagsAsync(ids, MessageFlags.Seen, true, cancellationToken);
+        else
+            await folder.RemoveFlagsAsync(ids, MessageFlags.Seen, true, cancellationToken);
+    }
+
+    public async Task MoveEmailAsync(
+        string accountId, string emailId, string destinationFolder,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(destinationFolder))
+            throw new ArgumentException("Destination folder is required.", nameof(destinationFolder));
+
+        var (folderName, uidValidity, uid) = ParseEmailId(emailId);
+        var cfg = await ResolveConfigAsync(accountId);
+
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, folderName, FolderAccess.ReadWrite, cancellationToken);
+        EnsureUidValidity(folder, uidValidity, accountId, folderName);
+
+        var dest = await client.GetFolderAsync(destinationFolder, cancellationToken);
+        await folder.MoveToAsync(new[] { new UniqueId(uid) }, dest, cancellationToken);
+    }
+
+    // ── Calendar / contact methods are unsupported ───────────────────
+
+    private static NotSupportedException Unsupported(string operation) =>
+        new($"Provider '{ProviderName}' does not support {operation}. " +
+            "IMAP accounts are email-only; pick a different account for this operation.");
+
+    public Task<IEnumerable<CalendarInfo>> ListCalendarsAsync(string accountId, CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task<IEnumerable<CalendarEvent>> GetCalendarEventsAsync(
+        string accountId, string? calendarId = null, DateTime? startDate = null, DateTime? endDate = null,
+        int count = 50, CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task<CalendarEvent?> GetCalendarEventDetailsAsync(
+        string accountId, string calendarId, string eventId, CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task<string> CreateEventAsync(
+        string accountId, string? calendarId, string subject, DateTime start, DateTime end,
+        string? location = null, List<string>? attendees = null, string? body = null,
+        string? timeZone = null, CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task UpdateEventAsync(
+        string accountId, string calendarId, string eventId, string? subject = null,
+        DateTime? start = null, DateTime? end = null, string? location = null,
+        List<string>? attendees = null, string? timeZone = null,
+        CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task DeleteEventAsync(
+        string accountId, string calendarId, string eventId, CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task RespondToEventAsync(
+        string accountId, string calendarId, string eventId, string response,
+        string? comment = null, CancellationToken cancellationToken = default) =>
+        throw Unsupported("calendar operations");
+
+    public Task<IEnumerable<Contact>> GetContactsAsync(
+        string accountId, int count = 50, CancellationToken cancellationToken = default) =>
+        throw Unsupported("contact operations");
+
+    public Task<IEnumerable<Contact>> SearchContactsAsync(
+        string accountId, string query, int count = 50, CancellationToken cancellationToken = default) =>
+        throw Unsupported("contact operations");
+
+    public Task<Contact?> GetContactDetailsAsync(
+        string accountId, string contactId, CancellationToken cancellationToken = default) =>
+        throw Unsupported("contact operations");
+
+    public Task<string> CreateContactAsync(
+        string accountId, string displayName, string? givenName = null, string? surname = null,
+        List<string>? emailAddresses = null, List<string>? phoneNumbers = null,
+        string? jobTitle = null, string? companyName = null, string? notes = null,
+        CancellationToken cancellationToken = default) =>
+        throw Unsupported("contact operations");
+
+    public Task UpdateContactAsync(
+        string accountId, string contactId, string? displayName = null, string? givenName = null,
+        string? surname = null, List<string>? emailAddresses = null, List<string>? phoneNumbers = null,
+        string? jobTitle = null, string? companyName = null, string? notes = null,
+        string? etag = null, CancellationToken cancellationToken = default) =>
+        throw Unsupported("contact operations");
+
+    public Task DeleteContactAsync(
+        string accountId, string contactId, CancellationToken cancellationToken = default) =>
+        throw Unsupported("contact operations");
+
+    // ── Mappers ──────────────────────────────────────────────────────
+
+    private static EmailMessage SummaryToEmail(
+        IMessageSummary s, string folder, uint uidValidity, string accountId)
+    {
+        var envelope = s.Envelope;
+        var from = envelope?.From.Mailboxes.FirstOrDefault();
+        var hasAttachments = s.Attachments?.Any() ?? false;
+
+        var listUnsub = HeaderValue(s.Headers, "List-Unsubscribe");
+        var listUnsubPost = HeaderValue(s.Headers, "List-Unsubscribe-Post");
+
+        return new EmailMessage
+        {
+            Id = FormatEmailId(folder, uidValidity, s.UniqueId.Id),
+            AccountId = accountId,
+            Subject = envelope?.Subject ?? string.Empty,
+            From = from?.Address ?? string.Empty,
+            FromName = from?.Name ?? string.Empty,
+            To = envelope?.To.Mailboxes.Select(a => a.Address).ToList() ?? [],
+            Cc = envelope?.Cc.Mailboxes.Select(a => a.Address).ToList() ?? [],
+            Body = string.Empty,
+            BodyFormat = "text",
+            ReceivedDateTime = (s.InternalDate ?? envelope?.Date ?? DateTimeOffset.MinValue).UtcDateTime,
+            IsRead = s.Flags?.HasFlag(MessageFlags.Seen) ?? false,
+            HasAttachments = hasAttachments,
+            UnsubscribeInfo = UnsubscribeHeaderParser.Parse(listUnsub, listUnsubPost)
+        };
+    }
+
+    private static EmailMessage MessageToEmail(
+        MimeMessage m, string folder, uint uidValidity, uint uid, string accountId, bool isRead)
+    {
+        var from = m.From.Mailboxes.FirstOrDefault();
+        var (body, format) = ExtractBody(m);
+
+        var attachments = m.Attachments
+            .OfType<MimePart>()
+            .Select(p => new EmailAttachment
+            {
+                Name = p.FileName ?? "(unnamed)",
+                Size = p.Content?.Stream?.Length ?? 0,
+                ContentType = p.ContentType?.MimeType ?? "application/octet-stream"
+            })
+            .ToList();
+
+        return new EmailMessage
+        {
+            Id = FormatEmailId(folder, uidValidity, uid),
+            AccountId = accountId,
+            Subject = m.Subject ?? string.Empty,
+            From = from?.Address ?? string.Empty,
+            FromName = from?.Name ?? string.Empty,
+            To = m.To.Mailboxes.Select(a => a.Address).ToList(),
+            Cc = m.Cc.Mailboxes.Select(a => a.Address).ToList(),
+            Body = body,
+            BodyFormat = format,
+            ReceivedDateTime = m.Date.UtcDateTime,
+            IsRead = isRead,
+            HasAttachments = attachments.Count > 0,
+            Attachments = attachments,
+            UnsubscribeInfo = UnsubscribeHeaderParser.Parse(
+                m.Headers["List-Unsubscribe"],
+                m.Headers["List-Unsubscribe-Post"])
+        };
+    }
+
+    private static (string Body, string Format) ExtractBody(MimeMessage m)
+    {
+        if (m.HtmlBody is { Length: > 0 } html)
+            return (html, "html");
+        if (m.TextBody is { Length: > 0 } text)
+            return (text, "text");
+        return (string.Empty, "text");
+    }
+
+    private static string? HeaderValue(HeaderList? headers, string name)
+    {
+        if (headers is null) return null;
+        var header = headers.FirstOrDefault(h => string.Equals(h.Field, name, StringComparison.OrdinalIgnoreCase));
+        return header?.Value;
+    }
+
+    private static IEnumerable<string> SplitAddresses(string addresses) =>
+        addresses.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static void EnsureUidValidity(IMailFolder folder, uint expected, string accountId, string folderName)
+    {
+        if (folder.UidValidity == expected) return;
+        throw new InvalidOperationException(
+            $"Email ID is no longer valid: folder '{folderName}' on account '{accountId}' " +
+            $"has UIDVALIDITY {folder.UidValidity}, but the ID was created with {expected}. " +
+            "Re-list the folder to get current IDs.");
+    }
+
+    private sealed record ImapAccountConfig(
+        string AccountId,
+        string ImapHost, int ImapPort,
+        string SmtpHost, int SmtpPort,
+        string Username, string Password,
+        string InboxFolder, string SentFolder, string TrashFolder);
+}

--- a/src/CalendarMcp.Core/Providers/ProviderServiceFactory.cs
+++ b/src/CalendarMcp.Core/Providers/ProviderServiceFactory.cs
@@ -13,6 +13,7 @@ public class ProviderServiceFactory : IProviderServiceFactory
     private readonly IOutlookComProviderService _outlookProvider;
     private readonly IIcsProviderService _icsProvider;
     private readonly IJsonCalendarProviderService _jsonProvider;
+    private readonly IImapProviderService _imapProvider;
     private readonly ILogger<ProviderServiceFactory> _logger;
 
     public ProviderServiceFactory(
@@ -21,6 +22,7 @@ public class ProviderServiceFactory : IProviderServiceFactory
         IOutlookComProviderService outlookProvider,
         IIcsProviderService icsProvider,
         IJsonCalendarProviderService jsonProvider,
+        IImapProviderService imapProvider,
         ILogger<ProviderServiceFactory> logger)
     {
         _m365Provider = m365Provider;
@@ -28,6 +30,7 @@ public class ProviderServiceFactory : IProviderServiceFactory
         _outlookProvider = outlookProvider;
         _icsProvider = icsProvider;
         _jsonProvider = jsonProvider;
+        _imapProvider = imapProvider;
         _logger = logger;
     }
 
@@ -40,6 +43,7 @@ public class ProviderServiceFactory : IProviderServiceFactory
             "outlook.com" or "outlook" or "hotmail" => _outlookProvider,
             "ics" or "icalendar" => _icsProvider,
             "json" or "json-calendar" => _jsonProvider,
+            "imap" or "imap-smtp" => _imapProvider,
             _ => throw new ArgumentException($"Unknown account type: {accountType}", nameof(accountType))
         };
 

--- a/src/CalendarMcp.Core/Security/PasswordProtector.cs
+++ b/src/CalendarMcp.Core/Security/PasswordProtector.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace CalendarMcp.Core.Security;
+
+/// <summary>
+/// Encrypts and decrypts secrets that live inside <c>ProviderConfig</c> dictionaries,
+/// using ASP.NET DataProtection with a keystore persisted under the application
+/// data directory.
+///
+/// Protected values are stored with an "ENC:" prefix so callers can tell encrypted
+/// values from any pre-existing plaintext. Unprotect treats values without the
+/// prefix as already-plaintext and returns them unchanged, which keeps the
+/// transition from plaintext-stored credentials to encrypted ones safe.
+/// </summary>
+public sealed class PasswordProtector
+{
+    /// <summary>Marker prefix on stored encrypted values.</summary>
+    public const string EncryptedPrefix = "ENC:";
+
+    /// <summary>DataProtection purpose string. Constant so a value protected by one
+    /// host can be unprotected by another running off the same keystore.</summary>
+    public const string Purpose = "CalendarMcp.ProviderConfig.Password";
+
+    private readonly IDataProtector _protector;
+
+    public PasswordProtector(IDataProtectionProvider provider)
+    {
+        _protector = provider.CreateProtector(Purpose);
+    }
+
+    /// <summary>
+    /// Encrypts a plaintext password and returns it with the <see cref="EncryptedPrefix"/>.
+    /// Empty/whitespace input is returned unchanged so empty form fields don't get encrypted.
+    /// </summary>
+    public string Protect(string plaintext)
+    {
+        if (string.IsNullOrEmpty(plaintext))
+            return plaintext;
+
+        return EncryptedPrefix + _protector.Protect(plaintext);
+    }
+
+    /// <summary>
+    /// Returns the plaintext password from a stored value. Values lacking the
+    /// <see cref="EncryptedPrefix"/> are treated as plaintext and returned as-is —
+    /// this is intentional, so configurations migrating from the older plaintext
+    /// schema continue to work.
+    /// </summary>
+    public string Unprotect(string stored)
+    {
+        if (string.IsNullOrEmpty(stored))
+            return stored;
+
+        if (!stored.StartsWith(EncryptedPrefix, StringComparison.Ordinal))
+            return stored;
+
+        return _protector.Unprotect(stored[EncryptedPrefix.Length..]);
+    }
+
+    /// <summary>
+    /// Indicates whether <paramref name="stored"/> appears to be a protected blob.
+    /// Useful in form mappers that need to distinguish "user pasted a new password"
+    /// from "form is round-tripping the previously-saved one".
+    /// </summary>
+    public static bool IsProtected(string? stored) =>
+        !string.IsNullOrEmpty(stored) && stored.StartsWith(EncryptedPrefix, StringComparison.Ordinal);
+}

--- a/src/CalendarMcp.Core/Services/IProviderServices.cs
+++ b/src/CalendarMcp.Core/Services/IProviderServices.cs
@@ -36,3 +36,11 @@ public interface IIcsProviderService : IProviderService
 public interface IJsonCalendarProviderService : IProviderService
 {
 }
+
+/// <summary>
+/// IMAP/SMTP provider service for any mailbox supporting standard IMAP and SMTP.
+/// Email-only — calendar and contact methods throw NotSupportedException.
+/// </summary>
+public interface IImapProviderService : IProviderService
+{
+}

--- a/src/CalendarMcp.Core/Tools/ListAccountsTool.cs
+++ b/src/CalendarMcp.Core/Tools/ListAccountsTool.cs
@@ -79,6 +79,9 @@ public sealed class ListAccountsTool(
             "ics" or "icalendar" => [
                 new { name = "calendar", readOnly = true }
             ],
+            "imap" or "imap-smtp" => [
+                new { name = "email", readOnly = false }
+            ],
             "json" or "json-calendar" => GetJsonCapabilities(account),
             _ => [
                 new { name = "calendar", readOnly = false }

--- a/src/CalendarMcp.Core/Tools/SendEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/SendEmailTool.cs
@@ -15,9 +15,9 @@ public sealed class SendEmailTool(
     IProviderServiceFactory providerFactory,
     ILogger<SendEmailTool> logger)
 {
-    [McpServerTool, Description("Send an email. If accountId is omitted, smart routing selects the account whose domains match the recipient's email domain; if no match, the first configured account is used. Provide accountId explicitly to guarantee which account sends the message.")]
+    [McpServerTool, Description("Send an email. If accountId is omitted, smart routing selects the account whose domains match the first recipient's email domain; if no match, the first configured account is used. Provide accountId explicitly to guarantee which account sends the message.")]
     public async Task<string> SendEmail(
-        [Description("Recipient email address")] string to,
+        [Description("Recipient email address(es). Supply as a JSON array of strings, e.g. [\"alice@example.com\"] or [\"alice@example.com\",\"bob@example.com\"].")] List<string> to,
         [Description("Email subject line")] string subject,
         [Description("Email body content. Use HTML when bodyFormat is 'html' (the default).")] string body,
         [Description("Account ID to send from. Omit to use smart routing (matches recipient domain to account domains, then falls back to first account). Obtain from list_accounts.")] string? accountId = null,
@@ -26,9 +26,19 @@ public sealed class SendEmailTool(
     {
         // Strip CDATA wrappers if present (LLMs sometimes wrap content in XML CDATA)
         body = StripCdataWrapper(body);
-        
+
+        if (to is null || to.Count == 0)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "At least one recipient address is required in the 'to' field."
+            });
+        }
+
+        var toJoined = string.Join(", ", to);
+
         logger.LogInformation("Sending email: to={To}, subject={Subject}, accountId={AccountId}",
-            to, subject, accountId);
+            toJoined, subject, accountId);
 
         try
         {
@@ -49,8 +59,8 @@ public sealed class SendEmailTool(
             }
             else
             {
-                // Smart routing: extract domain from recipient
-                var recipientDomain = to.Split('@').LastOrDefault();
+                // Smart routing: extract domain from the first recipient
+                var recipientDomain = to[0].Split('@').LastOrDefault();
                 if (!string.IsNullOrEmpty(recipientDomain))
                 {
                     var matchingAccounts = accountRegistry.GetAccountsByDomain(recipientDomain).ToList();
@@ -89,7 +99,7 @@ public sealed class SendEmailTool(
             // Send email
             var provider = providerFactory.GetProvider(account.Provider);
             var messageId = await provider.SendEmailAsync(
-                account.Id, to, subject, body, bodyFormat, cc, CancellationToken.None);
+                account.Id, toJoined, subject, body, bodyFormat, cc, CancellationToken.None);
 
             var result = new
             {
@@ -98,7 +108,7 @@ public sealed class SendEmailTool(
                 accountUsed = account.Id
             };
 
-            logger.LogInformation("Sent email from account {AccountId} to {To}", account.Id, to);
+            logger.LogInformation("Sent email from account {AccountId} to {To}", account.Id, toJoined);
 
             return JsonSerializer.Serialize(result, new JsonSerializerOptions
             {
@@ -111,7 +121,9 @@ public sealed class SendEmailTool(
             return JsonSerializer.Serialize(new
             {
                 error = "Failed to send email",
-                message = ex.Message
+                errorType = ex.GetType().Name,
+                message = ex.Message,
+                inner = ex.InnerException?.Message
             });
         }
     }

--- a/src/CalendarMcp.HttpServer/BlazorAdmin/AccountFormModels.cs
+++ b/src/CalendarMcp.HttpServer/BlazorAdmin/AccountFormModels.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using CalendarMcp.Core.Models;
+using CalendarMcp.Core.Providers;
+using CalendarMcp.Core.Security;
 
 namespace CalendarMcp.HttpServer.BlazorAdmin;
 
@@ -55,9 +57,20 @@ public class CreateAccountFormModel : AccountFormBase
     /// <summary>Local path or OneDrive path for emails, depending on JsonSource.</summary>
     public string EmailsPath { get; set; } = "";
 
-    public AccountInfo ToAccountInfo()
+    // IMAP/SMTP. Defaults are Gmail-tuned but every value is overridable.
+    public string ImapHost { get; set; } = ImapProviderService.DefaultImapHost;
+    public int ImapPort { get; set; } = ImapProviderService.DefaultImapPort;
+    public string SmtpHost { get; set; } = ImapProviderService.DefaultSmtpHost;
+    public int SmtpPort { get; set; } = ImapProviderService.DefaultSmtpPort;
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+    public string InboxFolder { get; set; } = ImapProviderService.DefaultInbox;
+    public string SentFolder { get; set; } = ImapProviderService.DefaultSent;
+    public string TrashFolder { get; set; } = ImapProviderService.DefaultTrash;
+
+    public AccountInfo ToAccountInfo(PasswordProtector? passwordProtector = null)
     {
-        var providerConfig = BuildProviderConfig();
+        var providerConfig = BuildProviderConfig(passwordProtector);
         return new AccountInfo
         {
             Id = Id,
@@ -70,7 +83,7 @@ public class CreateAccountFormModel : AccountFormBase
         };
     }
 
-    private Dictionary<string, string> BuildProviderConfig() => Provider.ToLowerInvariant() switch
+    private Dictionary<string, string> BuildProviderConfig(PasswordProtector? passwordProtector) => Provider.ToLowerInvariant() switch
     {
         "microsoft365" => new()
         {
@@ -93,8 +106,29 @@ public class CreateAccountFormModel : AccountFormBase
             ["CacheTtlMinutes"] = CacheTtlMinutes.ToString()
         },
         "json" => BuildJsonProviderConfig(),
+        "imap" => BuildImapProviderConfig(passwordProtector),
         _ => []
     };
+
+    private Dictionary<string, string> BuildImapProviderConfig(PasswordProtector? passwordProtector)
+    {
+        var encryptedPassword = passwordProtector is not null
+            ? passwordProtector.Protect(Password)
+            : Password;
+
+        return new Dictionary<string, string>
+        {
+            ["imapHost"] = ImapHost,
+            ["imapPort"] = ImapPort.ToString(),
+            ["smtpHost"] = SmtpHost,
+            ["smtpPort"] = SmtpPort.ToString(),
+            ["username"] = Username,
+            ["password"] = encryptedPassword,
+            ["inboxFolder"] = InboxFolder,
+            ["sentFolder"] = SentFolder,
+            ["trashFolder"] = TrashFolder
+        };
+    }
 
     private Dictionary<string, string> BuildJsonProviderConfig()
     {
@@ -158,7 +192,22 @@ public class EditAccountFormModel : AccountFormBase
     /// <summary>Local path or OneDrive path for emails, depending on JsonSource.</summary>
     public string EmailsPath { get; set; } = "";
 
-    public static EditAccountFormModel FromAccountInfo(AccountInfo account)
+    // IMAP/SMTP
+    public string ImapHost { get; set; } = ImapProviderService.DefaultImapHost;
+    public int ImapPort { get; set; } = ImapProviderService.DefaultImapPort;
+    public string SmtpHost { get; set; } = ImapProviderService.DefaultSmtpHost;
+    public int SmtpPort { get; set; } = ImapProviderService.DefaultSmtpPort;
+    public string Username { get; set; } = "";
+    /// <summary>
+    /// Password as shown in the form. On load, decrypted via PasswordProtector.
+    /// On save, re-encrypted before being persisted.
+    /// </summary>
+    public string Password { get; set; } = "";
+    public string InboxFolder { get; set; } = ImapProviderService.DefaultInbox;
+    public string SentFolder { get; set; } = ImapProviderService.DefaultSent;
+    public string TrashFolder { get; set; } = ImapProviderService.DefaultTrash;
+
+    public static EditAccountFormModel FromAccountInfo(AccountInfo account, PasswordProtector? passwordProtector = null)
     {
         var model = new EditAccountFormModel
         {
@@ -205,12 +254,29 @@ public class EditAccountFormModel : AccountFormBase
                 if (int.TryParse(GetConfigValue(config, "cacheTtlMinutes"), out var jsonTtl))
                     model.JsonCacheTtlMinutes = jsonTtl;
                 break;
+            case "imap":
+                model.ImapHost = GetConfigValue(config, "imapHost");
+                if (int.TryParse(GetConfigValue(config, "imapPort"), out var imapPort)) model.ImapPort = imapPort;
+                model.SmtpHost = GetConfigValue(config, "smtpHost");
+                if (int.TryParse(GetConfigValue(config, "smtpPort"), out var smtpPort)) model.SmtpPort = smtpPort;
+                model.Username = GetConfigValue(config, "username");
+                var storedPassword = GetConfigValue(config, "password");
+                model.Password = passwordProtector is not null
+                    ? passwordProtector.Unprotect(storedPassword)
+                    : storedPassword;
+                model.InboxFolder = GetConfigValue(config, "inboxFolder");
+                if (string.IsNullOrEmpty(model.InboxFolder)) model.InboxFolder = ImapProviderService.DefaultInbox;
+                model.SentFolder = GetConfigValue(config, "sentFolder");
+                if (string.IsNullOrEmpty(model.SentFolder)) model.SentFolder = ImapProviderService.DefaultSent;
+                model.TrashFolder = GetConfigValue(config, "trashFolder");
+                if (string.IsNullOrEmpty(model.TrashFolder)) model.TrashFolder = ImapProviderService.DefaultTrash;
+                break;
         }
 
         return model;
     }
 
-    public AccountInfo ToAccountInfo()
+    public AccountInfo ToAccountInfo(PasswordProtector? passwordProtector = null)
     {
         return new AccountInfo
         {
@@ -220,11 +286,11 @@ public class EditAccountFormModel : AccountFormBase
             Domains = ParseDomains(),
             Enabled = Enabled,
             Priority = Priority,
-            ProviderConfig = BuildProviderConfig()
+            ProviderConfig = BuildProviderConfig(passwordProtector)
         };
     }
 
-    private Dictionary<string, string> BuildProviderConfig() => Provider.ToLowerInvariant() switch
+    private Dictionary<string, string> BuildProviderConfig(PasswordProtector? passwordProtector) => Provider.ToLowerInvariant() switch
     {
         "microsoft365" => new()
         {
@@ -247,8 +313,29 @@ public class EditAccountFormModel : AccountFormBase
             ["CacheTtlMinutes"] = CacheTtlMinutes.ToString()
         },
         "json" => BuildJsonProviderConfig(),
+        "imap" => BuildImapProviderConfig(passwordProtector),
         _ => []
     };
+
+    private Dictionary<string, string> BuildImapProviderConfig(PasswordProtector? passwordProtector)
+    {
+        var encryptedPassword = passwordProtector is not null
+            ? passwordProtector.Protect(Password)
+            : Password;
+
+        return new Dictionary<string, string>
+        {
+            ["imapHost"] = ImapHost,
+            ["imapPort"] = ImapPort.ToString(),
+            ["smtpHost"] = SmtpHost,
+            ["smtpPort"] = SmtpPort.ToString(),
+            ["username"] = Username,
+            ["password"] = encryptedPassword,
+            ["inboxFolder"] = InboxFolder,
+            ["sentFolder"] = SentFolder,
+            ["trashFolder"] = TrashFolder
+        };
+    }
 
     private Dictionary<string, string> BuildJsonProviderConfig()
     {

--- a/src/CalendarMcp.HttpServer/Components/Pages/AddAccount.razor
+++ b/src/CalendarMcp.HttpServer/Components/Pages/AddAccount.razor
@@ -3,9 +3,11 @@
 @attribute [Authorize]
 @using CalendarMcp.Auth
 @using CalendarMcp.Core.Models
+@using CalendarMcp.Core.Security
 @using CalendarMcp.HttpServer.BlazorAdmin
 @inject IAccountConfigurationService ConfigService
 @inject NavigationManager Navigation
+@inject PasswordProtector PasswordProtector
 
 <h1 class="mb-4">
     <i class="bi bi-plus-circle me-2"></i>Add Account
@@ -105,6 +107,59 @@ else
                         <InputText class="form-control" type="password" @bind-Value="_model.ClientSecret" placeholder="Google Cloud client secret" />
                     </div>
                 </div>
+                break;
+
+            case "imap":
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Username</label>
+                        <InputText class="form-control" @bind-Value="_model.Username" placeholder="user@example.com" />
+                        <div class="form-text">Typically the email address.</div>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Password</label>
+                        <InputText class="form-control" type="password" @bind-Value="_model.Password"
+                                   placeholder="App password (encrypted at rest)" />
+                        <div class="form-text">For Gmail, use an <a href="https://myaccount.google.com/apppasswords" target="_blank" rel="noopener">app password</a>. Stored encrypted via ASP.NET DataProtection.</div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">IMAP Host</label>
+                        <InputText class="form-control" @bind-Value="_model.ImapHost" />
+                    </div>
+                    <div class="col-md-2 mb-3">
+                        <label class="form-label">IMAP Port</label>
+                        <InputNumber class="form-control" @bind-Value="_model.ImapPort" />
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <label class="form-label">SMTP Host</label>
+                        <InputText class="form-control" @bind-Value="_model.SmtpHost" />
+                    </div>
+                    <div class="col-md-1 mb-3">
+                        <label class="form-label">Port</label>
+                        <InputNumber class="form-control" @bind-Value="_model.SmtpPort" />
+                    </div>
+                </div>
+                <details class="mb-3">
+                    <summary class="text-muted small mb-2">Advanced — folder names</summary>
+                    <div class="row mt-2">
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Inbox</label>
+                            <InputText class="form-control" @bind-Value="_model.InboxFolder" />
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Sent</label>
+                            <InputText class="form-control" @bind-Value="_model.SentFolder" />
+                            <div class="form-text">Sent messages are APPENDed here.</div>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Trash</label>
+                            <InputText class="form-control" @bind-Value="_model.TrashFolder" />
+                            <div class="form-text">Deletes move messages here rather than expunging.</div>
+                        </div>
+                    </div>
+                </details>
                 break;
 
             case "ics":
@@ -287,6 +342,7 @@ else
         {
             "outlook.com" => "outlook.com, hotmail.com, live.com",
             "google" => "gmail.com",
+            "imap" => "gmail.com",
             _ => ""
         };
 
@@ -310,7 +366,7 @@ else
 
         try
         {
-            var accountInfo = _model.ToAccountInfo();
+            var accountInfo = _model.ToAccountInfo(PasswordProtector);
 
             // Server-side validation
             var (idValid, idError) = AccountValidation.ValidateAccountId(accountInfo.Id);
@@ -340,7 +396,7 @@ else
         provider is "microsoft365" or "outlook.com" or "google";
 
     private static bool HasEmailSupport(string provider) =>
-        provider is "microsoft365" or "outlook.com" or "google";
+        provider is "microsoft365" or "outlook.com" or "google" or "imap";
 
     private static string GetProviderDisplayName(string provider) => provider switch
     {
@@ -349,6 +405,7 @@ else
         "google" => "Google",
         "ics" => "ICS Feed",
         "json" => "JSON File",
+        "imap" => "IMAP/SMTP",
         _ => provider
     };
 
@@ -357,6 +414,7 @@ else
         "microsoft365" => "company.com",
         "outlook.com" => "outlook.com, hotmail.com, live.com",
         "google" => "gmail.com",
+        "imap" => "gmail.com",
         _ => "optional"
     };
 }

--- a/src/CalendarMcp.HttpServer/Components/Pages/Dashboard.razor
+++ b/src/CalendarMcp.HttpServer/Components/Pages/Dashboard.razor
@@ -62,6 +62,7 @@ else
                 <AccountCard Account="item.Account"
                              IsAuthenticated="item.IsAuthenticated"
                              AuthRequired="item.AuthRequired"
+                             HasInteractiveAuth="item.HasInteractiveAuth"
                              AuthDelegateAccountId="@item.AuthDelegateAccountId"
                              FlowStatus="@item.FlowStatus"
                              OnLogout="HandleLogout" />
@@ -101,6 +102,7 @@ else
                     Account = account,
                     IsAuthenticated = isAuth,
                     AuthRequired = authRequired,
+                    HasInteractiveAuth = HasInteractiveAuthFlow(account.Provider),
                     AuthDelegateAccountId = AccountValidation.GetAuthDelegateAccountId(account),
                     FlowStatus = flowStatus.Status != "not_found" ? flowStatus.Status : null
                 });
@@ -162,9 +164,22 @@ else
                 => File.Exists(ConfigurationPaths.GetMsalCachePath(account.Id)),
             "google" or "gmail" or "google workspace"
                 => File.Exists(GetGoogleTokenFilePath(account.Id)),
+            // IMAP/SMTP carries its credential (the password) directly in providerConfig —
+            // there's no separate token cache. The account is "authenticated" iff the
+            // password is populated; no Authenticate button is needed.
+            "imap" or "imap-smtp"
+                => account.ProviderConfig.TryGetValue("password", out var pw) && !string.IsNullOrWhiteSpace(pw),
             _ => false
         };
     }
+
+    private static bool HasInteractiveAuthFlow(string provider) => provider.ToLowerInvariant() switch
+    {
+        "microsoft365" or "m365" or "outlook" or "outlook.com" or "hotmail" => true,
+        "google" or "gmail" or "google workspace" => true,
+        // IMAP credentials live in the account config; no separate sign-in.
+        _ => false
+    };
 
     private static string GetGoogleTokenFilePath(string accountId)
     {
@@ -177,6 +192,7 @@ else
         public required AccountInfo Account { get; init; }
         public bool IsAuthenticated { get; init; }
         public bool AuthRequired { get; init; } = true;
+        public bool HasInteractiveAuth { get; init; } = true;
         public string? AuthDelegateAccountId { get; init; }
         public string? FlowStatus { get; init; }
     }

--- a/src/CalendarMcp.HttpServer/Components/Pages/EditAccount.razor
+++ b/src/CalendarMcp.HttpServer/Components/Pages/EditAccount.razor
@@ -3,9 +3,11 @@
 @attribute [Authorize]
 @using CalendarMcp.Auth
 @using CalendarMcp.Core.Models
+@using CalendarMcp.Core.Security
 @using CalendarMcp.HttpServer.BlazorAdmin
 @inject IAccountConfigurationService ConfigService
 @inject NavigationManager Navigation
+@inject PasswordProtector PasswordProtector
 
 <h1 class="mb-4">
     <i class="bi bi-pencil me-2"></i>Edit Account
@@ -194,6 +196,55 @@ else if (_model is not null)
                     <InputNumber class="form-control" @bind-Value="_model.JsonCacheTtlMinutes" />
                 </div>
                 break;
+
+            case "imap":
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Username</label>
+                        <InputText class="form-control" @bind-Value="_model.Username" />
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Password</label>
+                        <InputText class="form-control" type="password" @bind-Value="_model.Password" />
+                        <div class="form-text">Stored encrypted via ASP.NET DataProtection.</div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">IMAP Host</label>
+                        <InputText class="form-control" @bind-Value="_model.ImapHost" />
+                    </div>
+                    <div class="col-md-2 mb-3">
+                        <label class="form-label">IMAP Port</label>
+                        <InputNumber class="form-control" @bind-Value="_model.ImapPort" />
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <label class="form-label">SMTP Host</label>
+                        <InputText class="form-control" @bind-Value="_model.SmtpHost" />
+                    </div>
+                    <div class="col-md-1 mb-3">
+                        <label class="form-label">Port</label>
+                        <InputNumber class="form-control" @bind-Value="_model.SmtpPort" />
+                    </div>
+                </div>
+                <details class="mb-3">
+                    <summary class="text-muted small mb-2">Advanced — folder names</summary>
+                    <div class="row mt-2">
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Inbox</label>
+                            <InputText class="form-control" @bind-Value="_model.InboxFolder" />
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Sent</label>
+                            <InputText class="form-control" @bind-Value="_model.SentFolder" />
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Trash</label>
+                            <InputText class="form-control" @bind-Value="_model.TrashFolder" />
+                        </div>
+                    </div>
+                </details>
+                break;
         }
 
         <div class="row">
@@ -270,7 +321,7 @@ else if (_model is not null)
             }
             else
             {
-                _model = EditAccountFormModel.FromAccountInfo(account);
+                _model = EditAccountFormModel.FromAccountInfo(account, PasswordProtector);
                 await LoadMicrosoftAccountsAsync();
             }
         }
@@ -309,7 +360,7 @@ else if (_model is not null)
 
         try
         {
-            var accountInfo = _model.ToAccountInfo();
+            var accountInfo = _model.ToAccountInfo(PasswordProtector);
 
             var (cfgValid, cfgError) = AccountValidation.ValidateProviderConfig(accountInfo.Provider, accountInfo.ProviderConfig);
             if (!cfgValid) { _error = cfgError; return; }

--- a/src/CalendarMcp.HttpServer/Components/Shared/AccountCard.razor
+++ b/src/CalendarMcp.HttpServer/Components/Shared/AccountCard.razor
@@ -60,7 +60,7 @@
         <div class="mt-3 d-flex flex-wrap align-items-center gap-2">
             <span class="badge bg-info text-dark">@Account.Provider</span>
             <div class="btn-group btn-group-sm">
-                @if (Account.Enabled && AuthRequired)
+                @if (Account.Enabled && AuthRequired && HasInteractiveAuth)
                 {
                     <a href="/admin/ui/auth/@Account.Id" class="btn btn-outline-primary" title="Authenticate">
                         <i class="bi bi-key"></i>
@@ -69,7 +69,7 @@
                 <a href="/admin/ui/accounts/@Account.Id/edit" class="btn btn-outline-secondary" title="Edit">
                     <i class="bi bi-pencil"></i>
                 </a>
-                @if (IsAuthenticated && AuthRequired)
+                @if (IsAuthenticated && AuthRequired && HasInteractiveAuth)
                 {
                     <button class="btn btn-outline-warning" title="Logout" @onclick="HandleLogout" disabled="@_loggingOut">
                         @if (_loggingOut)
@@ -100,6 +100,15 @@
     [Parameter]
     public bool AuthRequired { get; set; } = true;
 
+    /// <summary>
+    /// True when the account has an interactive auth flow (OAuth providers).
+    /// IMAP and similar providers carry their credential directly in the account
+    /// config and have no separate sign-in step, so the Authenticate / Logout
+    /// buttons don't apply.
+    /// </summary>
+    [Parameter]
+    public bool HasInteractiveAuth { get; set; } = true;
+
     [Parameter]
     public string? AuthDelegateAccountId { get; set; }
 
@@ -124,6 +133,7 @@
         "google" or "gmail" or "google workspace" => "bi-google",
         "ics" => "bi-calendar-event",
         "json" => "bi-filetype-json",
+        "imap" or "imap-smtp" => "bi-envelope-at",
         _ => "bi-envelope"
     };
 }

--- a/src/CalendarMcp.HttpServer/Components/Shared/ProviderPicker.razor
+++ b/src/CalendarMcp.HttpServer/Components/Shared/ProviderPicker.razor
@@ -32,6 +32,7 @@
         new("microsoft365", "Microsoft 365", "bi-microsoft", "Work/school accounts with Exchange Online"),
         new("outlook.com", "Outlook.com", "bi-microsoft", "Personal Microsoft accounts (Hotmail, Live)"),
         new("google", "Google", "bi-google", "Gmail and Google Workspace accounts"),
+        new("imap", "IMAP/SMTP", "bi-envelope-at", "Any IMAP/SMTP mailbox — Gmail, Fastmail, custom (email-only)"),
         new("ics", "ICS Feed", "bi-calendar-event", "Subscribe to any ICS/iCal calendar feed URL"),
         new("json", "JSON File", "bi-filetype-json", "Local or OneDrive JSON calendar export")
     ];

--- a/src/CalendarMcp.Tests/Auth/AccountValidationTests.cs
+++ b/src/CalendarMcp.Tests/Auth/AccountValidationTests.cs
@@ -216,6 +216,34 @@ public class AccountValidationTests
     }
 
     [TestMethod]
+    public void ValidateProviderConfig_Imap_RequiresHostsAndCredentials()
+    {
+        var config = new Dictionary<string, string>
+        {
+            ["imapHost"] = "imap.example.com",
+            ["smtpHost"] = "smtp.example.com",
+            ["username"] = "user@example.com",
+            ["password"] = "ENC:..."
+        };
+        var (isValid, _) = AccountValidation.ValidateProviderConfig("imap", config);
+        Assert.IsTrue(isValid);
+    }
+
+    [TestMethod]
+    public void ValidateProviderConfig_Imap_MissingPassword_Fails()
+    {
+        var config = new Dictionary<string, string>
+        {
+            ["imapHost"] = "imap.example.com",
+            ["smtpHost"] = "smtp.example.com",
+            ["username"] = "user@example.com"
+        };
+        var (isValid, error) = AccountValidation.ValidateProviderConfig("imap", config);
+        Assert.IsFalse(isValid);
+        Assert.IsTrue(error?.Contains("password", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
     public void ValidateProviderConfig_CaseInsensitiveKeys()
     {
         var config = new Dictionary<string, string>

--- a/src/CalendarMcp.Tests/Providers/ImapProviderServiceTests.cs
+++ b/src/CalendarMcp.Tests/Providers/ImapProviderServiceTests.cs
@@ -1,0 +1,58 @@
+using CalendarMcp.Core.Providers;
+
+namespace CalendarMcp.Tests.Providers;
+
+[TestClass]
+public class ImapProviderServiceTests
+{
+    [TestMethod]
+    public void FormatEmailId_ProducesParseableId()
+    {
+        var id = ImapProviderService.FormatEmailId("INBOX", 1234567890u, 4567u);
+
+        Assert.AreEqual("INBOX/1234567890/4567", id);
+    }
+
+    [TestMethod]
+    public void ParseEmailId_RoundTripsSimpleFolder()
+    {
+        var id = ImapProviderService.FormatEmailId("INBOX", 1234567890u, 4567u);
+
+        var (folder, uidValidity, uid) = ImapProviderService.ParseEmailId(id);
+
+        Assert.AreEqual("INBOX", folder);
+        Assert.AreEqual(1234567890u, uidValidity);
+        Assert.AreEqual(4567u, uid);
+    }
+
+    [TestMethod]
+    public void ParseEmailId_PreservesFolderWithInternalSlashes()
+    {
+        // Gmail folder names like "[Gmail]/Trash" contain a literal slash that
+        // must survive parsing — only the trailing two slashes delimit the IDs.
+        var id = ImapProviderService.FormatEmailId("[Gmail]/Trash", 999u, 42u);
+
+        var (folder, uidValidity, uid) = ImapProviderService.ParseEmailId(id);
+
+        Assert.AreEqual("[Gmail]/Trash", folder);
+        Assert.AreEqual(999u, uidValidity);
+        Assert.AreEqual(42u, uid);
+    }
+
+    [TestMethod]
+    [DataRow("not-an-id")]
+    [DataRow("INBOX/abc/4567")]
+    [DataRow("INBOX/1234/notanumber")]
+    public void ParseEmailId_RejectsInvalidFormats(string bad)
+    {
+        Assert.ThrowsException<FormatException>(() => ImapProviderService.ParseEmailId(bad));
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void ParseEmailId_RejectsEmptyOrWhitespace(string bad)
+    {
+        Assert.ThrowsException<ArgumentException>(() => ImapProviderService.ParseEmailId(bad));
+    }
+}

--- a/src/CalendarMcp.Tests/Providers/ProviderServiceFactoryTests.cs
+++ b/src/CalendarMcp.Tests/Providers/ProviderServiceFactoryTests.cs
@@ -13,7 +13,8 @@ public class ProviderServiceFactoryTests
         IGoogleProviderService? google = null,
         IOutlookComProviderService? outlook = null,
         IIcsProviderService? ics = null,
-        IJsonCalendarProviderService? json = null)
+        IJsonCalendarProviderService? json = null,
+        IImapProviderService? imap = null)
     {
         return new ProviderServiceFactory(
             m365 ?? new IM365ProviderServiceCreateExpectations().Instance(),
@@ -21,6 +22,7 @@ public class ProviderServiceFactoryTests
             outlook ?? new IOutlookComProviderServiceCreateExpectations().Instance(),
             ics ?? new IIcsProviderServiceCreateExpectations().Instance(),
             json ?? new IJsonCalendarProviderServiceCreateExpectations().Instance(),
+            imap ?? new IImapProviderServiceCreateExpectations().Instance(),
             NullLogger<ProviderServiceFactory>.Instance);
     }
 
@@ -94,6 +96,20 @@ public class ProviderServiceFactoryTests
         var provider = factory.GetProvider(alias);
 
         Assert.AreSame(json, provider);
+    }
+
+    [TestMethod]
+    [DataRow("imap")]
+    [DataRow("imap-smtp")]
+    public void GetProvider_ImapAliases_ReturnsImapProvider(string alias)
+    {
+        var imapExpectations = new IImapProviderServiceCreateExpectations();
+        var imap = imapExpectations.Instance();
+        var factory = CreateFactory(imap: imap);
+
+        var provider = factory.GetProvider(alias);
+
+        Assert.AreSame(imap, provider);
     }
 
     [TestMethod]

--- a/src/CalendarMcp.Tests/RockSetup.cs
+++ b/src/CalendarMcp.Tests/RockSetup.cs
@@ -9,3 +9,4 @@ using Rocks;
 [assembly: Rock(typeof(IOutlookComProviderService), BuildType.Create)]
 [assembly: Rock(typeof(IIcsProviderService), BuildType.Create)]
 [assembly: Rock(typeof(IJsonCalendarProviderService), BuildType.Create)]
+[assembly: Rock(typeof(IImapProviderService), BuildType.Create)]

--- a/src/CalendarMcp.Tests/Security/PasswordProtectorTests.cs
+++ b/src/CalendarMcp.Tests/Security/PasswordProtectorTests.cs
@@ -1,0 +1,70 @@
+using CalendarMcp.Core.Security;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace CalendarMcp.Tests.Security;
+
+[TestClass]
+public class PasswordProtectorTests
+{
+    private static PasswordProtector CreateProtector()
+    {
+        var provider = DataProtectionProvider.Create("CalendarMcpTests");
+        return new PasswordProtector(provider);
+    }
+
+    [TestMethod]
+    public void Protect_WrapsValueWithEncPrefix()
+    {
+        var protector = CreateProtector();
+
+        var protectedValue = protector.Protect("hunter2");
+
+        Assert.IsTrue(protectedValue.StartsWith(PasswordProtector.EncryptedPrefix, StringComparison.Ordinal));
+        Assert.IsTrue(PasswordProtector.IsProtected(protectedValue));
+    }
+
+    [TestMethod]
+    public void Protect_Unprotect_RoundTrip()
+    {
+        var protector = CreateProtector();
+        const string secret = "correct horse battery staple";
+
+        var roundTripped = protector.Unprotect(protector.Protect(secret));
+
+        Assert.AreEqual(secret, roundTripped);
+    }
+
+    [TestMethod]
+    public void Unprotect_PassesPlainTextThroughUnchanged()
+    {
+        // Plaintext-stored values from before encryption was introduced must
+        // continue to be readable so users don't have to re-enter passwords.
+        var protector = CreateProtector();
+        const string plain = "not-yet-encrypted";
+
+        var result = protector.Unprotect(plain);
+
+        Assert.AreEqual(plain, result);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
+    public void Protect_PassesEmptyOrNullThroughUnchanged(string? input)
+    {
+        var protector = CreateProtector();
+
+        var result = protector.Protect(input!);
+
+        Assert.AreEqual(input, result);
+    }
+
+    [TestMethod]
+    public void IsProtected_OnlyMatchesEncPrefix()
+    {
+        Assert.IsFalse(PasswordProtector.IsProtected(null));
+        Assert.IsFalse(PasswordProtector.IsProtected(""));
+        Assert.IsFalse(PasswordProtector.IsProtected("plaintext"));
+        Assert.IsTrue(PasswordProtector.IsProtected("ENC:something"));
+    }
+}

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
@@ -32,7 +32,7 @@ public class SendEmailToolTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail("to@example.com", "Subject", "Body", "acc-1");
+        var result = await tool.SendEmail(new List<string> { "to@example.com" }, "Subject", "Body", "acc-1");
         var doc = JsonDocument.Parse(result);
 
         Assert.IsTrue(doc.RootElement.GetProperty("success").GetBoolean());
@@ -54,7 +54,7 @@ public class SendEmailToolTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail("to@example.com", "Subject", "Body", "nonexistent");
+        var result = await tool.SendEmail(new List<string> { "to@example.com" }, "Subject", "Body", "nonexistent");
         var doc = JsonDocument.Parse(result);
 
         Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
@@ -72,10 +72,25 @@ public class SendEmailToolTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail("to@unknown.com", "Subject", "Body");
+        var result = await tool.SendEmail(new List<string> { "to@unknown.com" }, "Subject", "Body");
         var doc = JsonDocument.Parse(result);
 
         Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));
         regExp.Verify();
+    }
+
+    [TestMethod]
+    public async Task SendEmail_EmptyToList_ReturnsError()
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail([], "Subject", "Body", "acc-1");
+        var doc = JsonDocument.Parse(result);
+
+        var error = doc.RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("recipient", StringComparison.OrdinalIgnoreCase) ?? false);
     }
 }


### PR DESCRIPTION
Closes #50.

## Summary

- New `imap` provider (alias `imap-smtp`) via MailKit. Email-only by design — calendar/contact methods throw `NotSupportedException`. Designed for unattended bot mailboxes where consumer-Gmail OAuth's 7-day refresh-token expiry is a non-starter.
- Defaults are Gmail-tuned (`imap.gmail.com:993`, `smtp.gmail.com:587`, `[Gmail]/Sent Mail`, `[Gmail]/Trash`) but **not** hard-coded — every value is overridable per account, so the provider works for Fastmail, Apple iCloud, custom IMAP servers, etc.
- Password is encrypted at rest via ASP.NET DataProtection. Stored values carry an `ENC:` prefix. Legacy plaintext values are still readable so manually-edited entries continue to work; the next save through the UI re-encrypts them.
- Email IDs encode `folder/uidvalidity/uid` so deletes/moves survive folder changes and the provider can detect UIDVALIDITY mismatches when the underlying folder is recreated.
- VersionPrefix bumped to 1.2.0; image rebuilt and deployed to k8s.

## Test plan

- [x] `dotnet test` — 219/219 passing (18 new tests covering PasswordProtector round-trip, ENC-prefix passthrough, ImapProviderService ID parsing/format, ProviderServiceFactory `imap`/`imap-smtp` dispatch, and IMAP config validation)
- [x] All five projects build clean (`Core`, `Auth`, `HttpServer`, `StdioServer`, `Cli`, `Tests`)
- [x] Built `rockylhotka/calendar-mcp-http:1.2.0` and `:latest`; assembly version `1.2.0.0` verified inside the image
- [x] Pushed both tags to Docker Hub
- [x] Deployed to k8s (`calendar-mcp` namespace) — pod `calendar-mcp-55f459d9f4-dng78` running, registry loaded all six existing accounts cleanly, DataProtection wired up successfully
- [ ] End-to-end IMAP smoke test against Gmail with an app password (next step — add `rockybotagent@gmail.com` via the admin UI)

## Notable details

- **Microsoft.Extensions.\* bumped from 10.0.3 to 10.0.7** in `Core`, `Auth`, and `Cli` to satisfy what DataProtection 10.0.7 transitively requires — this also clears critical/high vulnerability advisories on the older versions.
- **DataProtection keystore** persists to `<data-dir>/keys/` (so `/app/data/keys/` in k8s, `%LOCALAPPDATA%\CalendarMcp\keys\` locally). Both HttpServer and StdioServer share it automatically via `AddCalendarMcpCore`.
- **Connection management** is open-per-call for the first cut. Pooling/IDLE noted as a follow-up if measurements show contention.
- **Migrating Google's `ClientSecret` to `PasswordProtector`** is intentionally **not** part of this PR — separate small follow-up.

## Documentation updated

- `README.md` — provider list
- `docs/providers.md` — full IMAP section with config schema and ID format
- `docs/configuration.md` — IMAP config example with key reference
- `docs/security.md` — password encryption-at-rest section, threat model
- `docs/authentication.md` — IMAP auth path pointing to setup guide
- `docs/IMPLEMENTATION-STATUS.md` — IMAP listed as implemented
- `docs/IMAP-SETUP.md` — new Gmail app-password walkthrough, troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
