### PR TITLE
Email attachments: send, upload, fetch, store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Build solution
         run: dotnet build calendar-mcp.slnx --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test calendar-mcp.slnx --configuration Release --no-build --verbosity normal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.3</VersionPrefix>
+    <VersionPrefix>1.2.4</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.2.3</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.4</VersionPrefix>
+    <VersionPrefix>1.2.5</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.5</VersionPrefix>
+    <VersionPrefix>1.2.6</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The server exposes these tools to AI assistants:
 - **get_emails** / **search_emails** — Read and search email across accounts
 - **get_email_details** — Get full email content
 - **get_contextual_email_summary** — AI-powered topic clustering and persona analysis
-- **send_email** — Send email with smart domain-based routing
+- **send_email** — Send email with smart domain-based routing; supports file attachments (base64-encoded, up to 25 MB total)
 - **list_calendars** / **get_calendar_events** — View calendars and events
 - **get_calendar_event_details** — Get full event details
 - **find_available_times** — Find free time across all calendars

--- a/changelogs/2026-05-02-email-attachments.md
+++ b/changelogs/2026-05-02-email-attachments.md
@@ -1,0 +1,174 @@
+# 2026-05-02: Email Attachments
+
+## Summary
+
+Extended the `send_email` MCP tool to accept file attachments. Attachments
+are passed inline as a JSON array of `{name, contentType, base64Content}`
+objects, so they round-trip cleanly through any MCP client (Claude
+Desktop, rockbot, etc.) without requiring filesystem access on the
+server. Supported on Microsoft 365, Outlook.com, Google Workspace/Gmail,
+and IMAP/SMTP accounts.
+
+## Changes Made
+
+### Core Library (CalendarMcp.Core)
+
+#### New Model
+- `Models/OutboundEmailAttachment.cs` — payload type for outbound
+  attachments. Distinct from the existing `EmailAttachment` (which
+  represents inbound attachment metadata on a received message).
+
+#### Interface Update
+- `Services/IProviderService.cs` — added an
+  `IReadOnlyList<OutboundEmailAttachment>?` parameter to
+  `SendEmailAsync`.
+
+#### Provider Implementations
+- `Providers/M365ProviderService.cs` — attaches via Microsoft Graph
+  `FileAttachment` on the `SendMail` request.
+- `Providers/OutlookComProviderService.cs` — same as M365 (shared
+  Graph code path).
+- `Providers/GraphAttachmentBuilder.cs` (new) — shared helper that
+  builds Graph `FileAttachment` instances and validates the
+  per-attachment 3 MB cap that the Graph SendMail endpoint enforces.
+- `Providers/GoogleProviderService.cs` — switched from hand-rolled
+  RFC 2822 string assembly to MimeKit `BodyBuilder`, which handles
+  multipart/mixed correctly when attachments are present.
+- `Providers/ImapProviderService.cs` — uses MimeKit `BodyBuilder`
+  when attachments are present; preserves the existing single-part
+  `TextPart` body when there are none.
+- `Providers/MimeAttachmentBuilder.cs` (new) — shared helper used by
+  Google and IMAP/SMTP to add attachments to a MimeKit `BodyBuilder`.
+- `Providers/IcsProviderService.cs` — stub continues to throw
+  `NotSupportedException` (read-only).
+- `Providers/JsonCalendarProviderService.cs` — stub continues to
+  throw `NotSupportedException` (read-only).
+
+#### MCP Tool
+- `Tools/SendEmailTool.cs` — added the `attachments` parameter with
+  a description that fully specifies the JSON shape so MCP clients
+  surface it correctly. Validates name, content, and total payload
+  size (25 MB cap) before forwarding to the provider.
+
+#### Misc
+- `Tools/UnsubscribeFromEmailTool.cs` — updated to pass `null` for
+  the new attachments parameter on its internal `SendEmailAsync`
+  call.
+
+### Tests
+- `Tests/Tools/SendEmailToolTests.cs` — updated existing mocks for
+  the new signature, plus four new tests:
+  - `SendEmail_WithAttachment_PassesThroughToProvider`
+  - `SendEmail_AttachmentMissingName_ReturnsError`
+  - `SendEmail_AttachmentMissingContent_ReturnsError`
+  - `SendEmail_AttachmentExceedsTotalCap_ReturnsError`
+
+### CI
+- `.github/workflows/ci.yml` — gained a `dotnet test` step (added by
+  Copilot during this PR) so the new tests run on every push and PR.
+
+## API Details
+
+### Tool Signature
+```
+send_email(
+  to: string[],
+  subject: string,
+  body: string,
+  accountId?: string,
+  bodyFormat?: "html" | "text",
+  cc?: string[],
+  attachments?: OutboundEmailAttachment[]
+) -> JSON response
+```
+
+### Attachment Shape
+```json
+[
+  {
+    "name": "report.pdf",
+    "contentType": "application/pdf",
+    "base64Content": "<base64-encoded file bytes>"
+  }
+]
+```
+
+- **name** (required): file name as it should appear on the email
+- **contentType** (optional): MIME type; sniffed by the provider if
+  omitted
+- **base64Content** (required): file bytes encoded as one base64
+  string
+
+### Limits
+
+| Scope | Limit | Source |
+|-------|-------|--------|
+| Per attachment, M365 / Outlook.com | 3 MB | Microsoft Graph SendMail endpoint cap |
+| Per message, total decoded payload | 25 MB | Tool-level cap to keep MCP payloads tractable |
+| Google / IMAP per-attachment | (no extra cap beyond the 25 MB total) | MimeKit handles arbitrary multipart sizes |
+
+Larger files are rejected with an explicit error message rather than
+attempted and partially uploaded.
+
+## Provider Support
+
+| Provider | Supported | Implementation |
+|----------|-----------|----------------|
+| Microsoft 365 | Yes | Graph `FileAttachment` on `Me.SendMail` |
+| Outlook.com | Yes | Graph `FileAttachment` on `Me.SendMail` |
+| Google Workspace / Gmail | Yes | MimeKit `BodyBuilder` → base64url MIME → Gmail `Users.Messages.Send` |
+| IMAP / SMTP | Yes | MimeKit `BodyBuilder` → SMTP send + IMAP APPEND to Sent |
+| ICS | No | Read-only provider |
+| JSON file | No | Read-only provider |
+
+## Usage Example
+
+```
+User: "Email the Q2 report to alice@example.com"
+Assistant: [reads or generates the file]
+Assistant: [calls send_email with attachments=[{
+             name: "Q2-report.pdf",
+             contentType: "application/pdf",
+             base64Content: "JVBERi0xLjQK..."
+           }]]
+Assistant: "Sent — Q2-report.pdf (842 KB) is on its way to alice."
+```
+
+## Design Notes
+
+- **Inline base64, not file paths.** Path-based attachments would require
+  the MCP server to share a filesystem with whatever produced the file,
+  which doesn't hold for hosted clients like Claude Desktop or rockbot.
+  Inline base64 keeps the tool call self-contained.
+- **Type split.** `EmailAttachment` (existing, inbound) and
+  `OutboundEmailAttachment` (new) are kept distinct because they
+  describe different things — inbound carries metadata about an
+  attachment already on the server; outbound carries the actual bytes
+  to upload.
+- **Why not Graph upload sessions for >3 MB on M365?** Implementing
+  the draft + upload-session + send flow is non-trivial and would be
+  deferred unless real usage shows demand. Today the tool returns a
+  clear error pointing at the 3 MB cap.
+
+## Files Changed
+
+- `src/CalendarMcp.Core/Models/OutboundEmailAttachment.cs` (new)
+- `src/CalendarMcp.Core/Providers/GraphAttachmentBuilder.cs` (new)
+- `src/CalendarMcp.Core/Providers/MimeAttachmentBuilder.cs` (new)
+- `src/CalendarMcp.Core/Services/IProviderService.cs`
+- `src/CalendarMcp.Core/Providers/M365ProviderService.cs`
+- `src/CalendarMcp.Core/Providers/OutlookComProviderService.cs`
+- `src/CalendarMcp.Core/Providers/GoogleProviderService.cs`
+- `src/CalendarMcp.Core/Providers/ImapProviderService.cs`
+- `src/CalendarMcp.Core/Providers/IcsProviderService.cs`
+- `src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs`
+- `src/CalendarMcp.Core/Tools/SendEmailTool.cs`
+- `src/CalendarMcp.Core/Tools/UnsubscribeFromEmailTool.cs`
+- `src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs`
+- `.github/workflows/ci.yml` (added `dotnet test` step)
+
+## Related Documentation
+
+- [Microsoft Graph: Send mail with attachments](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
+- [Gmail API: Users.messages.send](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/send)
+- [MimeKit BodyBuilder](http://www.mimekit.net/docs/html/T_MimeKit_BodyBuilder.htm)

--- a/changelogs/2026-05-03-attachment-get-delete.md
+++ b/changelogs/2026-05-03-attachment-get-delete.md
@@ -1,0 +1,93 @@
+# 2026-05-03: Attachment GET / DELETE + Param-Name Hint
+
+## Summary
+
+Adds two HTTP endpoints on the attachment store and tightens the
+`emailId` parameter description so agents stop guessing `messageId`.
+
+- `GET /attachments/{id}` — read the bytes of a stored attachment
+  without consuming it. Returns raw bytes with `Content-Type` and
+  `Content-Disposition`. Useful when the agent has HTTP access and the
+  attachment exceeds the 1 MB inline cap on `get_email_attachment`.
+- `DELETE /attachments/{id}` — explicit cleanup before TTL.
+- Tool descriptions for `get_email_details` and `get_email_attachment`
+  now explicitly call out the parameter name (`emailId`, not `messageId`).
+
+## Why
+
+Observed during rockbot integration: after `get_email_attachment(mode=stash)`
+returned an `attachmentId`, the agent burned 4 tool calls and a web
+search trying to download it via various GET URL shapes
+(`/attachments/{id}`, `/attachment/{id}`, `/attachments/download/{id}`,
+`/api/attachments/{id}` — all 404). The original design intentionally
+omitted GET to keep "bytes never round-trip through the agent" as a
+guarantee. But that guarantee was already softened by
+`get_email_attachment(mode=inline)`, which returns base64 in the JSON
+tool result — so adding a real GET is the same capability over a better
+transport (no JSON envelope, no base64 inflation, no 1 MB cap).
+
+The agent also fumbled `messageId` vs `emailId` once. Description fix is
+free.
+
+## Design
+
+### Single-use vs. peek
+
+`send_email`'s consume semantics are unchanged — the ID is removed when
+send succeeds, preventing replay confusion. The new GET is **non-consuming**:
+it reads without removing, so the same ID can be GET'd multiple times and
+then still passed to `send_email`. The entry stays in the store until
+`send_email` consumes it, `DELETE` removes it, or TTL fires.
+
+### Auth
+
+Same as the existing POST: network-level only (Tailscale ACL on the
+public ingress; pod-internal `http://calendar-mcp.calendar-mcp:8080/`
+inside the cluster). IDs are 128 random bits, unguessable in practice.
+
+### Caps
+
+No new caps. Per-attachment size and global store size are unchanged from
+the upload endpoint (10 MB / 100 MB / 15 min TTL).
+
+## Changes Made
+
+### Core (CalendarMcp.Core)
+
+- `Services/IAttachmentStore.cs` — added `TryRead(id)` and `TryDelete(id)`
+  alongside the existing `TryConsume(id)`.
+- `Services/InMemoryAttachmentStore.cs` — implemented both. `TryRead`
+  also evicts lazily on expiry while it has the lock.
+
+### HTTP Server (CalendarMcp.HttpServer)
+
+- `Endpoints/AttachmentEndpoints.cs` —
+  - `GET /attachments/{id}` returns `Results.File` with the entry's
+    `Bytes`, `ContentType`, and `Name` for `Content-Disposition`.
+  - `DELETE /attachments/{id}` returns 204 on success, 404 if already
+    gone.
+
+### Tools (description tightening)
+
+- `Tools/GetEmailDetailsTool.cs`, `Tools/GetEmailAttachmentTool.cs` —
+  explicit "pass as parameter name 'emailId' (NOT 'messageId')" hint
+  on the email parameter description.
+- `Tools/GetEmailAttachmentTool.cs` — top-level description now mentions
+  `GET /attachments/{id}` as an HTTP-only escape hatch when the file is
+  too large for inline mode.
+
+### Tests (CalendarMcp.Tests)
+
+- `Services/InMemoryAttachmentStoreTests.cs` (3 new) —
+  `TryRead` is repeatable and doesn't block consume; `TryDelete` removes
+  + frees quota; `TryRead` evicts on expiry.
+- `Helpers/TestAttachmentStore.cs` — implements the new interface
+  methods.
+
+### Docs
+
+- `docs/mcp-tools.md` — new sections for `GET /attachments/{id}` and
+  `DELETE /attachments/{id}` with curl recipes; param-name reminder
+  callout under `get_email_attachment`.
+
+## Bumps `VersionPrefix` to 1.2.6.

--- a/changelogs/2026-05-03-attachment-upload-endpoint.md
+++ b/changelogs/2026-05-03-attachment-upload-endpoint.md
@@ -1,0 +1,122 @@
+# 2026-05-03: Attachment Upload Endpoint
+
+## Summary
+
+Adds an out-of-band HTTP upload path so agents can deliver attachment bytes
+to the MCP server *as binary* — without inflating their JSON tool call with
+megabytes of base64. Builds on the email-attachment work from 2026-05-02.
+
+`POST /attachments` (multipart) returns a short-lived `attachmentId`; the
+existing `send_email` tool now accepts that ID in lieu of `base64Content` per
+attachment. The server resolves the ID to bytes server-side and consumes the
+entry on send (single-use).
+
+Inline `base64Content` continues to work for stdio MCP clients (Claude
+Desktop, the local stdio mode of Claude Code) and tiny files where the
+upload round trip isn't worth it. M365 Copilot also stays on inline base64.
+
+## Why
+
+Base64-in-JSON is the only universal MCP shape, but it has real costs:
+
+- **Token bloat**: a 2 MB PDF becomes ~2.7 MB of base64 chars sitting in the
+  agent's tool call, eating into the context window.
+- **LLM emission**: hosted agents that must *emit* the base64 themselves
+  (rather than execute code that reads the file) hit truncation and
+  reliability issues quickly.
+- **Latency**: bytes traverse the LLM round trip even though the model has
+  no use for them.
+
+The k8s deployment has no shared filesystem, so a `filePath` parameter
+isn't an option. An out-of-band HTTP upload is the cleanest fit: agents
+that can `curl` (Claude Code, rockbot) skip base64 entirely; everyone else
+keeps the inline path.
+
+## Changes Made
+
+### Core Library (CalendarMcp.Core)
+
+#### New
+- `Services/IAttachmentStore.cs` — interface, `StoredAttachment` record,
+  `AttachmentStoreOptions` (per-attachment 10 MB, global 100 MB, 15 min TTL).
+- `Services/InMemoryAttachmentStore.cs` — single-process dictionary-backed
+  store. 22-char base64url IDs from `RandomNumberGenerator`. Lock-guarded
+  `Put`/`TryConsume`. Single-use semantics (consume removes the entry).
+  Lazy expiry on `TryConsume`; explicit `EvictExpired` for the sweeper.
+- `Configuration/ServiceCollectionExtensions.cs` — register
+  `IAttachmentStore` (singleton) and `AttachmentStoreOptions`.
+
+#### Updated
+- `Models/OutboundEmailAttachment.cs` — `Base64Content` is now nullable;
+  added `AttachmentId`. Exactly one of the two must be set per item.
+- `Tools/SendEmailTool.cs` — injects `IAttachmentStore`. Two-phase handling:
+  first pass validates shapes (rejects both/neither, missing `name` for
+  inline) without touching the store; second pass consumes any
+  `AttachmentId` entries and substitutes the resolved bytes before
+  dispatching to the provider. Provider implementations are unchanged.
+
+### HTTP Server (CalendarMcp.HttpServer)
+
+#### New
+- `Endpoints/AttachmentEndpoints.cs` — `POST /attachments` minimal API.
+  Accepts `multipart/form-data` with one `file` part. Returns `201` with
+  `{ attachmentId, name, contentType, size, expiresAt }`. Errors: `400`
+  (bad shape), `413` (per-file cap), `507` (global cap).
+- `Endpoints/AttachmentEvictionService.cs` — `BackgroundService` sweeping
+  the store every 60 s. Without it, expired entries would only be reclaimed
+  on next access.
+
+#### Updated
+- `Program.cs` — registers `AttachmentEvictionService` as a hosted service
+  and maps the upload endpoint as a sibling of `/mcp`. Same network-level
+  protection (Tailscale ACL, reverse proxy) — no admin token required, so
+  rockbot can `curl` directly.
+
+### Stdio Server (CalendarMcp.StdioServer)
+
+No changes. Stdio clients have no second channel for uploads, so they
+continue to use `base64Content` exclusively. The schema field is visible to
+them but passing an `attachmentId` will fail with "unknown or expired."
+
+### Documentation
+
+- `docs/mcp-tools.md` — rewrote the `attachments` parameter description to
+  cover both shapes; added an "Attachment uploads (HTTP mode)" section with
+  the request/response shape, limits, and a curl recipe.
+
+### Tests
+
+- `Services/InMemoryAttachmentStoreTests.cs` (5) — round-trip, oversized
+  file, global cap, expiry on consume, eviction reclaims quota.
+- `Tools/SendEmailToolAttachmentIdTests.cs` (5) — happy path, name/content
+  type override, unknown ID, both-shapes rejection, neither-shape rejection.
+- `Helpers/TestAttachmentStore.cs` — minimal `IAttachmentStore` for tests
+  (`Seed` to insert, `ConsumedIds` to assert).
+- `Tools/SendEmailToolTests.cs`, `Tools/SendEmailToolMcpInvocationTests.cs` —
+  updated constructor call to include the new dependency.
+
+## Limits
+
+| Limit | Value | Rationale |
+|---|---|---|
+| Per-upload size | 10 MB | Generous for any practical email attachment; well above Graph's 3 MB cap. |
+| Global store size | 100 MB | Caps worst-case pod memory pressure from attachments. |
+| TTL | 15 min | Long enough for compose-then-send workflows; short enough that abandoned uploads clear quickly. |
+| Sweep interval | 60 s | Reclaims memory shortly after expiry without spinning. |
+
+## Storage
+
+In-process memory only. No persistent volume, no disk writes. Pod restarts
+discard any in-flight uploads — the agent re-uploads on retry. If the
+HttpServer is ever scaled beyond one replica, swap `InMemoryAttachmentStore`
+for a Redis-backed implementation; the interface stays the same.
+
+## Security Notes
+
+- The endpoint sits at `/attachments`, sibling of `/mcp`, behind the same
+  network-level protection (Tailscale ACL). No admin token required.
+- Single-use consumption prevents replay confusion: once `send_email`
+  succeeds, the ID is gone.
+- The 100 MB global cap is the upper bound on memory abuse from a confused
+  or hostile reachable client.
+- IDs are 128 random bits (base64url-encoded), unguessable.

--- a/changelogs/2026-05-03-inbound-attachment-fetch.md
+++ b/changelogs/2026-05-03-inbound-attachment-fetch.md
@@ -1,0 +1,115 @@
+# 2026-05-03: Inbound Attachment Visibility + Fetch
+
+## Summary
+
+Closes the "I can't even see attachments on inbound mail" gap. Two changes:
+
+1. `get_email_details` now populates an `attachments[]` array with name,
+   size, contentType, and a provider-side `attachmentId` for each file.
+2. New tool `get_email_attachment` fetches the bytes for one attachment by
+   that ID. Defaults to **stash** mode — server-side download into the
+   existing attachment store, returns a store ID the agent can pass to
+   `send_email` to forward without the bytes ever transiting the LLM.
+   Optional **inline** mode returns base64 directly, capped at 1 MB.
+
+Together these enable the dominant inbound workflow ("show me what's
+attached / forward this attachment") without violating the same
+agent-friendly constraints we set up for the outbound side.
+
+## Why
+
+The original `EmailMessage` model had a `HasAttachments: bool` and an
+unpopulated `Attachments` list. None of the providers ever filled it in,
+and there was no fetch path. Agents could see "yes there's an attachment"
+but had no way to do anything about it.
+
+The most common inbound workflow is "forward this attachment to someone
+else." Designing the new tool around that case — server fetches from
+inbound provider directly into the attachment store, agent passes the ID
+to `send_email`, server hands bytes to outbound provider — keeps the LLM
+out of the byte path entirely. The `inline` mode exists for the secondary
+case where the agent needs to actually read the content (e.g., extract
+text from an inbox PDF).
+
+## Changes Made
+
+### Core Library (CalendarMcp.Core)
+
+#### Model
+- `Models/EmailMessage.cs` —
+  - Added `EmailAttachment.AttachmentId` (provider-side opaque ID).
+  - New `EmailAttachmentContent` value type (Name + ContentType + Bytes)
+    returned by the provider fetch method.
+
+#### Interface
+- `Services/IProviderService.cs` — added
+  `GetEmailAttachmentContentAsync(accountId, emailId, attachmentId, ct)`.
+
+#### Provider implementations
+- `Providers/M365ProviderService.cs` — `GetEmailDetailsAsync` now calls
+  `Me.Messages[id].Attachments.GetAsync` (metadata only, `$select` excludes
+  `contentBytes`) and returns each `FileAttachment`'s id/name/size/type.
+  `GetEmailAttachmentContentAsync` fetches one attachment by Graph id and
+  returns its `ContentBytes`.
+- `Providers/OutlookComProviderService.cs` — same Graph code path as M365.
+- `Providers/GoogleProviderService.cs` — walks `message.payload.parts`
+  recursively in `GetEmailDetailsAsync`, surfaces parts with non-empty
+  `Filename` using `body.attachmentId` as the ID. The fetch method calls
+  `Users.Messages.Attachments.Get` and base64url-decodes the body.
+- `Providers/ImapProviderService.cs` — uses positional synthetic IDs
+  (`part-0`, `part-1`, …) since IMAP has no native attachment ID. Fetch
+  re-opens the folder, re-pulls the message, walks `m.Attachments`, and
+  decodes the indexed `MimePart` content via MailKit.
+- `Providers/IcsProviderService.cs`, `Providers/JsonCalendarProviderService.cs` —
+  return `null` (no email attachments).
+
+#### Tool
+- `Tools/GetEmailAttachmentTool.cs` — new MCP tool. Defaults to stash mode;
+  inline mode capped at 1 MB. Returns shape that mirrors `POST /attachments`
+  response so the same agent code can consume both.
+- `Tools/GetEmailDetailsTool.cs` — projection now includes `attachmentId`.
+
+#### DI
+- `Configuration/ServiceCollectionExtensions.cs` — registers
+  `GetEmailAttachmentTool` as a singleton.
+
+### Servers
+- `CalendarMcp.HttpServer/Program.cs`,
+  `CalendarMcp.StdioServer/Program.cs` — register the new tool with MCP.
+
+### Tests
+- `Tests/Tools/GetEmailAttachmentToolTests.cs` (5) — stash mode round-trips
+  bytes through `InMemoryAttachmentStore`; inline mode under cap; inline
+  over cap rejects with guidance to use stash; provider returns null →
+  error; invalid mode → error.
+
+### Docs
+- `docs/mcp-tools.md` — `get_email_details` description updated to mention
+  `attachmentId` returns; full `get_email_attachment` section added with
+  both modes documented and example responses.
+
+## Limits
+
+- **Inline mode cap**: 1 MB. Forces agents toward stash for anything
+  bigger, keeping the JSON tool result small.
+- **Stash mode**: subject to the existing attachment store caps (10 MB
+  per attachment, 100 MB global, 15 min TTL).
+- **Per-attachment fetch is N+1**: each `get_email_attachment` call hits
+  the provider once. Agents should be selective. If batch fetch becomes a
+  real workflow, add `get_email_attachments_bulk` later.
+
+## Known Limitations
+
+- **IMAP IDs are positional and depend on message structure**: a `part-2`
+  reference assumes the message body hasn't been re-fetched into a
+  different shape. In practice the agent calls `get_email_details` then
+  immediately fetches the bytes; this hasn't been a problem.
+- **Graph `ItemAttachment` (forwarded message attachments) and
+  `ReferenceAttachment` (links) are excluded** from the visible list. Only
+  `FileAttachment` is supported. Adding these would require a different
+  fetch path (Graph returns nested `Message` objects for ItemAttachment).
+- **No streaming through the agent**. MCP tool results are single
+  JSON-RPC messages; even SSE transport delivers them as one payload.
+  Server-internal streaming for the forward case is a future possibility
+  (would skip the store and pipe inbound → outbound, plus require
+  outbound chunked upload sessions on Graph).

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -171,7 +171,9 @@ Get a contextual, topic-grouped summary of emails across all accounts with perso
 - **Cross-Account Analysis**: Reveals which topics span multiple accounts
 
 #### `get_email_details`
-Get full email content including body and attachments.
+Get full email content including body and attachment metadata. Each
+attachment in the response includes an `attachmentId`; pass it to
+`get_email_attachment` to fetch the bytes.
 
 **Parameters**:
 - `accountId`: Specific account ID (required)
@@ -193,9 +195,50 @@ Get full email content including body and attachments.
     {
       "name": "report.pdf",
       "size": 524288,
-      "contentType": "application/pdf"
+      "contentType": "application/pdf",
+      "attachmentId": "AAMkAG..."
     }
   ]
+}
+```
+
+#### `get_email_attachment`
+Fetch the bytes of one inbound attachment. Two modes:
+
+- **`stash`** (default): server downloads from the upstream provider, drops
+  the bytes into the same store used by `POST /attachments`, returns an
+  `attachmentId` you can pass directly to `send_email`. Bytes never round
+  trip through the LLM. This is the right mode for forward / re-attach
+  flows.
+- **`inline`**: returns base64 bytes directly. Capped at **1 MB**; larger
+  attachments must use `stash`. Use only when the agent itself needs to
+  read the file content.
+
+**Parameters**:
+- `accountId` (required): Account that owns the email.
+- `emailId` (required): Email message ID, from `get_email_details`.
+- `attachmentId` (required): Provider-side ID, from the `attachments[]`
+  array on `get_email_details`.
+- `mode` (default: `"stash"`): `"stash"` or `"inline"`.
+
+**Returns** (stash mode):
+```json
+{
+  "attachmentId": "AbCdEf1234...",
+  "name": "report.pdf",
+  "contentType": "application/pdf",
+  "size": 524288,
+  "expiresAt": "2026-05-03T15:42:00+00:00"
+}
+```
+
+**Returns** (inline mode):
+```json
+{
+  "name": "report.pdf",
+  "contentType": "application/pdf",
+  "size": 524288,
+  "base64Content": "<base64>"
 }
 ```
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -203,7 +203,11 @@ attachment in the response includes an `attachmentId`; pass it to
 ```
 
 #### `get_email_attachment`
-Fetch the bytes of one inbound attachment. Two modes:
+Fetch the bytes of one inbound attachment. Two modes.
+
+> **Parameter name reminder**: the email parameter is `emailId`, not
+> `messageId`. Same convention as `get_email_details`,
+> `delete_email`, and friends.
 
 - **`stash`** (default): server downloads from the upstream provider, drops
   the bytes into the same store used by `POST /attachments`, returns an
@@ -313,6 +317,34 @@ unsent uploads; the agent should re-upload on retry.
 curl example:
 ```sh
 curl -F file=@report.pdf https://calendar-mcp.tail920062.ts.net/attachments
+```
+
+#### `GET /attachments/{attachmentId}`
+
+Reads the bytes of a stored attachment **without consuming it**. Returns
+raw bytes with `Content-Type` and `Content-Disposition` headers populated
+from the upload metadata. Useful when the agent has HTTP access and the
+attachment is too large for `get_email_attachment(mode="inline")`'s 1 MB
+cap.
+
+The entry stays in the store until `send_email` consumes it,
+`DELETE /attachments/{id}` removes it, or the 15 min TTL expires. Multiple
+GETs against the same ID are fine.
+
+Returns `404` if the ID is unknown, expired, or already consumed.
+
+```sh
+curl -OJ https://calendar-mcp.tail920062.ts.net/attachments/AbCdEf1234
+```
+
+#### `DELETE /attachments/{attachmentId}`
+
+Removes an attachment from the store before its TTL. Returns `204` on
+success, `404` if the entry was already gone. Polite cleanup for agents
+that uploaded an attachment they decided not to send.
+
+```sh
+curl -X DELETE https://calendar-mcp.tail920062.ts.net/attachments/AbCdEf1234
 ```
 
 **Returns**:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -209,24 +209,68 @@ Send email from specific account (requires explicit account selection or smart r
 - `body`: Email body content
 - `bodyFormat` (default: "html"): "html" or "text"
 - `cc` (optional): CC recipients
-- `attachments` (optional): File attachments. JSON array of objects:
+- `attachments` (optional): File attachments. JSON array of objects. Each item
+  must use one of two shapes:
+
+  **Preferred — by ID (out-of-band upload):**
   ```json
-  [
-    {
-      "name": "report.pdf",
-      "contentType": "application/pdf",
-      "base64Content": "<base64-encoded file bytes>"
-    }
-  ]
+  [{ "attachmentId": "AbCdEf1234..." }]
+  ```
+  Upload the file to `POST /attachments` first (see [Attachment uploads](#attachment-uploads-http-mode)),
+  then pass the returned `attachmentId`. Avoids inflating the JSON tool call
+  with megabytes of base64. `name` and `contentType` from the upload are used
+  by default; pass them on the attachment object to override.
+
+  **Inline — by base64 (fallback):**
+  ```json
+  [{
+    "name": "report.pdf",
+    "contentType": "application/pdf",
+    "base64Content": "<base64-encoded file bytes>"
+  }]
   ```
   - `name` (required): file name as it should appear on the email
   - `contentType` (optional): MIME type; sniffed by the provider if omitted
   - `base64Content` (required): the file's bytes encoded as a single base64 string
 
-  Limits: total decoded payload across all attachments must stay under **25 MB**.
+  Use inline only for small files or when no out-of-band upload channel is
+  available (e.g. stdio MCP clients).
+
+  Limits: total decoded payload per message must stay under **25 MB**.
   Microsoft 365 and Outlook.com additionally cap each individual attachment at
-  **3 MB** (the Graph SendMail endpoint limit). Larger files are rejected with a
-  clear error. ICS and JSON file providers are read-only and reject any send.
+  **3 MB** (the Graph SendMail endpoint limit). Larger files are rejected with
+  a clear error. ICS and JSON file providers are read-only and reject any send.
+
+### Attachment uploads (HTTP mode)
+
+Available only on the HTTP server (`CalendarMcp.HttpServer`). Stdio clients
+must use `base64Content` inline.
+
+`POST /attachments` accepts `multipart/form-data` with exactly one `file`
+part and returns:
+
+```json
+{
+  "attachmentId": "AbCdEf1234...",
+  "name": "report.pdf",
+  "contentType": "application/pdf",
+  "size": 524288,
+  "expiresAt": "2026-05-03T15:42:00+00:00"
+}
+```
+
+Pass the returned `attachmentId` in a subsequent `send_email` call. Entries
+are **single-use** (the server consumes the bytes on send) and expire **15
+minutes** after upload. Per-upload limit: **10 MB**. Server-wide cap on the
+live attachment store: **100 MB**.
+
+Storage is in-process memory only — no disk, no PVC. Pod restart drops any
+unsent uploads; the agent should re-upload on retry.
+
+curl example:
+```sh
+curl -F file=@report.pdf https://calendar-mcp.tail920062.ts.net/attachments
+```
 
 **Returns**:
 ```json

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -209,7 +209,24 @@ Send email from specific account (requires explicit account selection or smart r
 - `body`: Email body content
 - `bodyFormat` (default: "html"): "html" or "text"
 - `cc` (optional): CC recipients
-- `attachments` (optional): Attachments to include
+- `attachments` (optional): File attachments. JSON array of objects:
+  ```json
+  [
+    {
+      "name": "report.pdf",
+      "contentType": "application/pdf",
+      "base64Content": "<base64-encoded file bytes>"
+    }
+  ]
+  ```
+  - `name` (required): file name as it should appear on the email
+  - `contentType` (optional): MIME type; sniffed by the provider if omitted
+  - `base64Content` (required): the file's bytes encoded as a single base64 string
+
+  Limits: total decoded payload across all attachments must stay under **25 MB**.
+  Microsoft 365 and Outlook.com additionally cap each individual attachment at
+  **3 MB** (the Graph SendMail endpoint limit). Larger files are rejected with a
+  clear error. ICS and JSON file providers are read-only and reject any send.
 
 **Returns**:
 ```json

--- a/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
@@ -47,6 +47,12 @@ public static class ServiceCollectionExtensions
         
         // Register account registry
         services.AddSingleton<IAccountRegistry, AccountRegistry>();
+
+        // Attachment store (in-memory; eviction sweeper is registered by the
+        // HTTP server only — stdio mode never uploads, so lazy expiry on
+        // consume is sufficient there).
+        services.AddOptions<AttachmentStoreOptions>();
+        services.AddSingleton<IAttachmentStore, InMemoryAttachmentStore>();
         
         // Register MCP tools (method-based pattern - just register the classes)
         services.AddSingleton<ListAccountsTool>();

--- a/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ListAccountsTool>();
         services.AddSingleton<GetEmailsTool>();
         services.AddSingleton<GetEmailDetailsTool>();
+        services.AddSingleton<GetEmailAttachmentTool>();
         services.AddSingleton<SearchEmailsTool>();
         services.AddSingleton<SendEmailTool>();
         services.AddSingleton<DeleteEmailTool>();

--- a/src/CalendarMcp.Core/Models/EmailAttachment.cs
+++ b/src/CalendarMcp.Core/Models/EmailAttachment.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace CalendarMcp.Core.Models;
+
+/// <summary>
+/// Represents a file to attach to an outbound email. The content is supplied
+/// as a base64-encoded string so the attachment can be transported through MCP
+/// without filesystem access on the server.
+/// </summary>
+public sealed class EmailAttachment
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; set; }
+
+    [JsonPropertyName("base64Content")]
+    public string Base64Content { get; set; } = "";
+
+    /// <summary>
+    /// Decodes <see cref="Base64Content"/> into raw bytes. Throws
+    /// <see cref="FormatException"/> if the value is not valid base64.
+    /// </summary>
+    public byte[] DecodeBytes() => Convert.FromBase64String(Base64Content);
+}

--- a/src/CalendarMcp.Core/Models/EmailMessage.cs
+++ b/src/CalendarMcp.Core/Models/EmailMessage.cs
@@ -77,11 +77,32 @@ public class EmailMessage
 }
 
 /// <summary>
-/// Email attachment information
+/// Metadata for an attachment on a received email. Bytes are not included;
+/// use the <c>get_email_attachment</c> tool with <see cref="AttachmentId"/>
+/// to fetch them.
 /// </summary>
 public class EmailAttachment
 {
     public required string Name { get; init; }
     public long Size { get; init; }
     public string ContentType { get; init; } = "application/octet-stream";
+
+    /// <summary>
+    /// Provider-side identifier for fetching the attachment content. Opaque
+    /// string scoped to the parent <see cref="EmailMessage.Id"/>. Format
+    /// varies by provider (Graph attachment id, Gmail body.attachmentId,
+    /// IMAP <c>part-N</c> index).
+    /// </summary>
+    public string? AttachmentId { get; init; }
+}
+
+/// <summary>
+/// Bytes for one inbound email attachment, as returned by
+/// <see cref="Services.IProviderService.GetEmailAttachmentContentAsync"/>.
+/// </summary>
+public sealed class EmailAttachmentContent
+{
+    public required string Name { get; init; }
+    public string? ContentType { get; init; }
+    public required byte[] Bytes { get; init; }
 }

--- a/src/CalendarMcp.Core/Models/OutboundEmailAttachment.cs
+++ b/src/CalendarMcp.Core/Models/OutboundEmailAttachment.cs
@@ -3,11 +3,13 @@ using System.Text.Json.Serialization;
 namespace CalendarMcp.Core.Models;
 
 /// <summary>
-/// Represents a file to attach to an outbound email. The content is supplied
-/// as a base64-encoded string so the attachment can be transported through MCP
+/// A file to attach to an outbound email being sent. Distinct from
+/// <see cref="EmailAttachment"/>, which represents an attachment on a
+/// received message (metadata only). The content is supplied as a
+/// base64-encoded string so the attachment can be transported through MCP
 /// without filesystem access on the server.
 /// </summary>
-public sealed class EmailAttachment
+public sealed class OutboundEmailAttachment
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = "";

--- a/src/CalendarMcp.Core/Models/OutboundEmailAttachment.cs
+++ b/src/CalendarMcp.Core/Models/OutboundEmailAttachment.cs
@@ -5,10 +5,21 @@ namespace CalendarMcp.Core.Models;
 /// <summary>
 /// A file to attach to an outbound email being sent. Distinct from
 /// <see cref="EmailAttachment"/>, which represents an attachment on a
-/// received message (metadata only). The content is supplied as a
-/// base64-encoded string so the attachment can be transported through MCP
-/// without filesystem access on the server.
+/// received message (metadata only).
 /// </summary>
+/// <remarks>
+/// Exactly one of <see cref="Base64Content"/> or <see cref="AttachmentId"/>
+/// must be set per item:
+/// <list type="bullet">
+/// <item><description><see cref="Base64Content"/>: inline bytes, base64-encoded.
+/// Convenient for tiny files but inflates the JSON tool call ~33% and
+/// fights LLM token limits.</description></item>
+/// <item><description><see cref="AttachmentId"/>: ID returned by a prior
+/// <c>POST /attachments</c> upload. Preferred for anything non-trivial; the
+/// server resolves the ID to bytes server-side and consumes the entry on
+/// success (single-use).</description></item>
+/// </list>
+/// </remarks>
 public sealed class OutboundEmailAttachment
 {
     [JsonPropertyName("name")]
@@ -18,11 +29,20 @@ public sealed class OutboundEmailAttachment
     public string? ContentType { get; set; }
 
     [JsonPropertyName("base64Content")]
-    public string Base64Content { get; set; } = "";
+    public string? Base64Content { get; set; }
+
+    [JsonPropertyName("attachmentId")]
+    public string? AttachmentId { get; set; }
 
     /// <summary>
     /// Decodes <see cref="Base64Content"/> into raw bytes. Throws
-    /// <see cref="FormatException"/> if the value is not valid base64.
+    /// <see cref="FormatException"/> if the value is not valid base64, or
+    /// <see cref="InvalidOperationException"/> if no inline content is set.
     /// </summary>
-    public byte[] DecodeBytes() => Convert.FromBase64String(Base64Content);
+    public byte[] DecodeBytes()
+    {
+        if (string.IsNullOrEmpty(Base64Content))
+            throw new InvalidOperationException("No inline base64 content to decode.");
+        return Convert.FromBase64String(Base64Content);
+    }
 }

--- a/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
@@ -268,7 +268,8 @@ public class GoogleProviderService : IGoogleProviderService
             // Augment with attachment metadata only on detail fetches.
             if (result.HasAttachments && message.Payload != null)
             {
-                CollectGmailAttachments(message.Payload, result.Attachments);
+                var index = 0;
+                CollectGmailAttachments(message.Payload, result.Attachments, ref index);
             }
             _logger.LogInformation("Retrieved email details for {EmailId} from Google account {AccountId}", emailId, accountId);
             return result;
@@ -280,10 +281,13 @@ public class GoogleProviderService : IGoogleProviderService
         }
     }
 
-    private static void CollectGmailAttachments(MessagePart part, List<EmailAttachment> result)
+    // Gmail surfaces an attachment whenever a part has a filename. We expose
+    // a positional id (part-0, part-1, ...) rather than Gmail's body.attachmentId
+    // because (a) small attachments (< 5 KB) come back inline in body.data with
+    // no separately-fetchable attachmentId, and (b) the positional scheme matches
+    // the IMAP provider so the agent sees a consistent shape.
+    private static void CollectGmailAttachments(MessagePart part, List<EmailAttachment> result, ref int index)
     {
-        // Gmail surfaces an attachment whenever a part has a filename; the
-        // bytes are fetched separately by Body.AttachmentId.
         if (!string.IsNullOrEmpty(part.Filename) && part.Body != null)
         {
             result.Add(new EmailAttachment
@@ -291,14 +295,33 @@ public class GoogleProviderService : IGoogleProviderService
                 Name = part.Filename,
                 Size = part.Body.Size ?? 0,
                 ContentType = part.MimeType ?? "application/octet-stream",
-                AttachmentId = part.Body.AttachmentId,
+                AttachmentId = $"part-{index}",
             });
+            index++;
         }
         if (part.Parts != null)
         {
             foreach (var child in part.Parts)
-                CollectGmailAttachments(child, result);
+                CollectGmailAttachments(child, result, ref index);
         }
+    }
+
+    private static MessagePart? FindGmailPartByIndex(MessagePart part, int target, ref int index)
+    {
+        if (!string.IsNullOrEmpty(part.Filename) && part.Body != null)
+        {
+            if (index == target) return part;
+            index++;
+        }
+        if (part.Parts != null)
+        {
+            foreach (var child in part.Parts)
+            {
+                var found = FindGmailPartByIndex(child, target, ref index);
+                if (found != null) return found;
+            }
+        }
+        return null;
     }
 
     public async Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
@@ -307,6 +330,14 @@ public class GoogleProviderService : IGoogleProviderService
         string attachmentId,
         CancellationToken cancellationToken = default)
     {
+        if (!attachmentId.StartsWith("part-", StringComparison.Ordinal)
+            || !int.TryParse(attachmentId.AsSpan(5), out var targetIndex)
+            || targetIndex < 0)
+        {
+            _logger.LogWarning("Invalid Gmail attachment id {AttachmentId}; expected 'part-N'", attachmentId);
+            return null;
+        }
+
         var credential = await GetCredentialAsync(accountId, cancellationToken);
         if (credential == null) return null;
 
@@ -314,41 +345,52 @@ public class GoogleProviderService : IGoogleProviderService
         {
             var service = CreateGmailService(credential);
 
-            // Need filename + content-type from the message payload — Gmail's
-            // attachments.get returns only the body bytes.
             var message = await service.Users.Messages.Get("me", emailId).ExecuteAsync(cancellationToken);
-            string? name = null;
-            string? contentType = null;
-            if (message?.Payload != null)
+            if (message?.Payload == null)
             {
-                FindGmailAttachmentMetadata(message.Payload, attachmentId, ref name, ref contentType);
-            }
-            if (name == null)
-            {
-                _logger.LogWarning("Attachment {AttachmentId} not found on message {EmailId}", attachmentId, emailId);
+                _logger.LogWarning("Message {EmailId} has no payload for attachment fetch", emailId);
                 return null;
             }
 
-            var part = await service.Users.Messages.Attachments.Get("me", emailId, attachmentId)
-                .ExecuteAsync(cancellationToken);
-            if (part?.Data == null)
+            var index = 0;
+            var part = FindGmailPartByIndex(message.Payload, targetIndex, ref index);
+            if (part == null)
             {
+                _logger.LogWarning("Attachment index {Index} not found on message {EmailId} (have {Count} attachments)",
+                    targetIndex, emailId, index);
                 return null;
             }
 
-            // Body.Data is base64url-encoded.
-            var b64 = part.Data.Replace('-', '+').Replace('_', '/');
-            switch (b64.Length % 4)
+            byte[] bytes;
+            if (!string.IsNullOrEmpty(part.Body?.Data))
             {
-                case 2: b64 += "=="; break;
-                case 3: b64 += "="; break;
+                // Small attachment — bytes come inline in the message body.
+                bytes = DecodeBase64UrlBytes(part.Body.Data);
             }
-            var bytes = Convert.FromBase64String(b64);
+            else if (!string.IsNullOrEmpty(part.Body?.AttachmentId))
+            {
+                // Larger attachment — separate fetch by Gmail's attachment id.
+                var attData = await service.Users.Messages.Attachments
+                    .Get("me", emailId, part.Body.AttachmentId)
+                    .ExecuteAsync(cancellationToken);
+                if (string.IsNullOrEmpty(attData?.Data))
+                {
+                    _logger.LogWarning("Gmail attachments.get returned no data for {AttachmentId} on {EmailId}",
+                        part.Body.AttachmentId, emailId);
+                    return null;
+                }
+                bytes = DecodeBase64UrlBytes(attData.Data);
+            }
+            else
+            {
+                _logger.LogWarning("Attachment part on {EmailId} has neither inline data nor attachmentId", emailId);
+                return null;
+            }
 
             return new EmailAttachmentContent
             {
-                Name = name,
-                ContentType = contentType,
+                Name = string.IsNullOrEmpty(part.Filename) ? "attachment" : part.Filename,
+                ContentType = part.MimeType,
                 Bytes = bytes,
             };
         }
@@ -360,24 +402,15 @@ public class GoogleProviderService : IGoogleProviderService
         }
     }
 
-    private static void FindGmailAttachmentMetadata(
-        MessagePart part, string attachmentId, ref string? name, ref string? contentType)
+    private static byte[] DecodeBase64UrlBytes(string base64Url)
     {
-        if (name != null) return;
-        if (part.Body?.AttachmentId == attachmentId)
+        var b64 = base64Url.Replace('-', '+').Replace('_', '/');
+        switch (b64.Length % 4)
         {
-            name = string.IsNullOrEmpty(part.Filename) ? "attachment" : part.Filename;
-            contentType = part.MimeType;
-            return;
+            case 2: b64 += "=="; break;
+            case 3: b64 += "="; break;
         }
-        if (part.Parts != null)
-        {
-            foreach (var child in part.Parts)
-            {
-                FindGmailAttachmentMetadata(child, attachmentId, ref name, ref contentType);
-                if (name != null) return;
-            }
-        }
+        return Convert.FromBase64String(b64);
     }
 
     public async Task<string> SendEmailAsync(

--- a/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
@@ -11,10 +11,11 @@ using Google.Apis.Services;
 using Google.Apis.Util.Store;
 using Microsoft.Extensions.Logging;
 using MimeKit;
-using MimeKit.Text;
 using System.Text;
 using Person = Google.Apis.PeopleService.v1.Data.Person;
 using Event = Google.Apis.Calendar.v3.Data.Event;
+// Disambiguate from MimeKit.MessagePart, introduced by the MimeKit imports above.
+using MessagePart = Google.Apis.Gmail.v1.Data.MessagePart;
 
 namespace CalendarMcp.Core.Providers;
 
@@ -281,7 +282,7 @@ public class GoogleProviderService : IGoogleProviderService
         string body,
         string bodyFormat = "html",
         List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var credential = await GetCredentialAsync(accountId, cancellationToken);

--- a/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
@@ -265,6 +265,11 @@ public class GoogleProviderService : IGoogleProviderService
             }
 
             var result = ConvertToEmailMessage(message, accountId, includeBody: true);
+            // Augment with attachment metadata only on detail fetches.
+            if (result.HasAttachments && message.Payload != null)
+            {
+                CollectGmailAttachments(message.Payload, result.Attachments);
+            }
             _logger.LogInformation("Retrieved email details for {EmailId} from Google account {AccountId}", emailId, accountId);
             return result;
         }
@@ -272,6 +277,106 @@ public class GoogleProviderService : IGoogleProviderService
         {
             _logger.LogError(ex, "Error getting email details for {EmailId} from Google account {AccountId}", emailId, accountId);
             return null;
+        }
+    }
+
+    private static void CollectGmailAttachments(MessagePart part, List<EmailAttachment> result)
+    {
+        // Gmail surfaces an attachment whenever a part has a filename; the
+        // bytes are fetched separately by Body.AttachmentId.
+        if (!string.IsNullOrEmpty(part.Filename) && part.Body != null)
+        {
+            result.Add(new EmailAttachment
+            {
+                Name = part.Filename,
+                Size = part.Body.Size ?? 0,
+                ContentType = part.MimeType ?? "application/octet-stream",
+                AttachmentId = part.Body.AttachmentId,
+            });
+        }
+        if (part.Parts != null)
+        {
+            foreach (var child in part.Parts)
+                CollectGmailAttachments(child, result);
+        }
+    }
+
+    public async Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId,
+        string emailId,
+        string attachmentId,
+        CancellationToken cancellationToken = default)
+    {
+        var credential = await GetCredentialAsync(accountId, cancellationToken);
+        if (credential == null) return null;
+
+        try
+        {
+            var service = CreateGmailService(credential);
+
+            // Need filename + content-type from the message payload — Gmail's
+            // attachments.get returns only the body bytes.
+            var message = await service.Users.Messages.Get("me", emailId).ExecuteAsync(cancellationToken);
+            string? name = null;
+            string? contentType = null;
+            if (message?.Payload != null)
+            {
+                FindGmailAttachmentMetadata(message.Payload, attachmentId, ref name, ref contentType);
+            }
+            if (name == null)
+            {
+                _logger.LogWarning("Attachment {AttachmentId} not found on message {EmailId}", attachmentId, emailId);
+                return null;
+            }
+
+            var part = await service.Users.Messages.Attachments.Get("me", emailId, attachmentId)
+                .ExecuteAsync(cancellationToken);
+            if (part?.Data == null)
+            {
+                return null;
+            }
+
+            // Body.Data is base64url-encoded.
+            var b64 = part.Data.Replace('-', '+').Replace('_', '/');
+            switch (b64.Length % 4)
+            {
+                case 2: b64 += "=="; break;
+                case 3: b64 += "="; break;
+            }
+            var bytes = Convert.FromBase64String(b64);
+
+            return new EmailAttachmentContent
+            {
+                Name = name,
+                ContentType = contentType,
+                Bytes = bytes,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching attachment {AttachmentId} on {EmailId} from Google account {AccountId}",
+                attachmentId, emailId, accountId);
+            return null;
+        }
+    }
+
+    private static void FindGmailAttachmentMetadata(
+        MessagePart part, string attachmentId, ref string? name, ref string? contentType)
+    {
+        if (name != null) return;
+        if (part.Body?.AttachmentId == attachmentId)
+        {
+            name = string.IsNullOrEmpty(part.Filename) ? "attachment" : part.Filename;
+            contentType = part.MimeType;
+            return;
+        }
+        if (part.Parts != null)
+        {
+            foreach (var child in part.Parts)
+            {
+                FindGmailAttachmentMetadata(child, attachmentId, ref name, ref contentType);
+                if (name != null) return;
+            }
         }
     }
 

--- a/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/GoogleProviderService.cs
@@ -10,6 +10,8 @@ using Google.Apis.PeopleService.v1.Data;
 using Google.Apis.Services;
 using Google.Apis.Util.Store;
 using Microsoft.Extensions.Logging;
+using MimeKit;
+using MimeKit.Text;
 using System.Text;
 using Person = Google.Apis.PeopleService.v1.Data.Person;
 using Event = Google.Apis.Calendar.v3.Data.Event;
@@ -273,12 +275,13 @@ public class GoogleProviderService : IGoogleProviderService
     }
 
     public async Task<string> SendEmailAsync(
-        string accountId, 
-        string to, 
-        string subject, 
-        string body, 
-        string bodyFormat = "html", 
-        List<string>? cc = null, 
+        string accountId,
+        string to,
+        string subject,
+        string body,
+        string bodyFormat = "html",
+        List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var credential = await GetCredentialAsync(accountId, cancellationToken);
@@ -291,31 +294,49 @@ public class GoogleProviderService : IGoogleProviderService
         {
             var service = CreateGmailService(credential);
 
-            // Create the email message in RFC 2822 format
-            var messageBuilder = new StringBuilder();
-            messageBuilder.AppendLine($"To: {to}");
-            if (cc != null && cc.Count > 0)
+            var mime = new MimeMessage();
+            foreach (var addr in to.Split(',', ';'))
             {
-                messageBuilder.AppendLine($"Cc: {string.Join(",", cc)}");
+                var trimmed = addr.Trim();
+                if (trimmed.Length > 0)
+                    mime.To.Add(MailboxAddress.Parse(trimmed));
             }
-            messageBuilder.AppendLine($"Subject: {subject}");
-            
-            if (bodyFormat.Equals("html", StringComparison.OrdinalIgnoreCase))
+            if (cc is { Count: > 0 })
             {
-                messageBuilder.AppendLine("Content-Type: text/html; charset=utf-8");
+                foreach (var addr in cc)
+                {
+                    var trimmed = addr.Trim();
+                    if (trimmed.Length > 0)
+                        mime.Cc.Add(MailboxAddress.Parse(trimmed));
+                }
             }
-            else
-            {
-                messageBuilder.AppendLine("Content-Type: text/plain; charset=utf-8");
-            }
-            
-            messageBuilder.AppendLine();
-            messageBuilder.AppendLine(body);
+            mime.Subject = subject;
 
-            var rawMessage = Convert.ToBase64String(Encoding.UTF8.GetBytes(messageBuilder.ToString()))
-                .Replace('+', '-')
-                .Replace('/', '_')
-                .Replace("=", "");
+            var builder = new BodyBuilder();
+            if (bodyFormat.Equals("html", StringComparison.OrdinalIgnoreCase))
+                builder.HtmlBody = body;
+            else
+                builder.TextBody = body;
+
+            if (attachments is { Count: > 0 })
+            {
+                foreach (var att in attachments)
+                {
+                    MimeAttachmentBuilder.Add(builder, att);
+                }
+            }
+
+            mime.Body = builder.ToMessageBody();
+
+            string rawMessage;
+            using (var ms = new MemoryStream())
+            {
+                await mime.WriteToAsync(ms, cancellationToken);
+                rawMessage = Convert.ToBase64String(ms.ToArray())
+                    .Replace('+', '-')
+                    .Replace('/', '_')
+                    .Replace("=", "");
+            }
 
             var gmailMessage = new Message
             {
@@ -333,6 +354,7 @@ public class GoogleProviderService : IGoogleProviderService
             throw;
         }
     }
+
 
     public async Task DeleteEmailAsync(
         string accountId,

--- a/src/CalendarMcp.Core/Providers/GraphAttachmentBuilder.cs
+++ b/src/CalendarMcp.Core/Providers/GraphAttachmentBuilder.cs
@@ -4,7 +4,7 @@ using Microsoft.Graph.Models;
 namespace CalendarMcp.Core.Providers;
 
 /// <summary>
-/// Converts <see cref="EmailAttachment"/> values into Microsoft Graph
+/// Converts <see cref="OutboundEmailAttachment"/> values into Microsoft Graph
 /// <see cref="FileAttachment"/> entries for inline use on the SendMail
 /// endpoint. Graph caps the SendMail request at ~4 MB total, so each
 /// attachment is rejected above 3 MB to leave headroom for the body and
@@ -15,7 +15,7 @@ internal static class GraphAttachmentBuilder
 {
     private const int MaxAttachmentBytes = 3 * 1024 * 1024;
 
-    public static List<Attachment> Build(IReadOnlyList<EmailAttachment> attachments)
+    public static List<Attachment> Build(IReadOnlyList<OutboundEmailAttachment> attachments)
     {
         var result = new List<Attachment>(attachments.Count);
         foreach (var att in attachments)

--- a/src/CalendarMcp.Core/Providers/GraphAttachmentBuilder.cs
+++ b/src/CalendarMcp.Core/Providers/GraphAttachmentBuilder.cs
@@ -1,0 +1,55 @@
+using CalendarMcp.Core.Models;
+using Microsoft.Graph.Models;
+
+namespace CalendarMcp.Core.Providers;
+
+/// <summary>
+/// Converts <see cref="EmailAttachment"/> values into Microsoft Graph
+/// <see cref="FileAttachment"/> entries for inline use on the SendMail
+/// endpoint. Graph caps the SendMail request at ~4 MB total, so each
+/// attachment is rejected above 3 MB to leave headroom for the body and
+/// recipients. Larger files would require the draft + upload-session flow,
+/// which is not yet supported.
+/// </summary>
+internal static class GraphAttachmentBuilder
+{
+    private const int MaxAttachmentBytes = 3 * 1024 * 1024;
+
+    public static List<Attachment> Build(IReadOnlyList<EmailAttachment> attachments)
+    {
+        var result = new List<Attachment>(attachments.Count);
+        foreach (var att in attachments)
+        {
+            if (string.IsNullOrWhiteSpace(att.Name))
+            {
+                throw new ArgumentException("Attachment name is required.", nameof(attachments));
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = att.DecodeBytes();
+            }
+            catch (FormatException ex)
+            {
+                throw new ArgumentException(
+                    $"Attachment '{att.Name}' has invalid base64 content.", nameof(attachments), ex);
+            }
+
+            if (bytes.Length > MaxAttachmentBytes)
+            {
+                throw new ArgumentException(
+                    $"Attachment '{att.Name}' is {bytes.Length:N0} bytes; the Microsoft Graph SendMail endpoint limits each attachment to {MaxAttachmentBytes:N0} bytes.",
+                    nameof(attachments));
+            }
+
+            result.Add(new FileAttachment
+            {
+                Name = att.Name,
+                ContentType = att.ContentType,
+                ContentBytes = bytes,
+            });
+        }
+        return result;
+    }
+}

--- a/src/CalendarMcp.Core/Providers/IcsProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/IcsProviderService.cs
@@ -266,7 +266,7 @@ public class IcsProviderService : IIcsProviderService
     public Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException("ICS provider does not support sending emails.");
 

--- a/src/CalendarMcp.Core/Providers/IcsProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/IcsProviderService.cs
@@ -266,6 +266,7 @@ public class IcsProviderService : IIcsProviderService
     public Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException("ICS provider does not support sending emails.");
 

--- a/src/CalendarMcp.Core/Providers/IcsProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/IcsProviderService.cs
@@ -263,6 +263,11 @@ public class IcsProviderService : IIcsProviderService
         CancellationToken cancellationToken = default)
         => Task.FromResult<EmailMessage?>(null);
 
+    public Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId, string emailId, string attachmentId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<EmailAttachmentContent?>(null);
+
     public Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,

--- a/src/CalendarMcp.Core/Providers/ImapProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/ImapProviderService.cs
@@ -271,6 +271,53 @@ public class ImapProviderService : IImapProviderService
         return MessageToEmail(message, folderName, uidValidity, uid, accountId, isRead);
     }
 
+    public async Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId, string emailId, string attachmentId,
+        CancellationToken cancellationToken = default)
+    {
+        // IMAP attachment ids are positional: "part-N".
+        if (!attachmentId.StartsWith("part-", StringComparison.Ordinal)
+            || !int.TryParse(attachmentId.AsSpan(5), out var index)
+            || index < 0)
+        {
+            _logger.LogWarning("Invalid IMAP attachment id {AttachmentId}", attachmentId);
+            return null;
+        }
+
+        var (folderName, uidValidity, uid) = ParseEmailId(emailId);
+        var cfg = await ResolveConfigAsync(accountId);
+
+        using var client = await OpenImapAsync(cfg, cancellationToken);
+        var folder = await OpenFolderAsync(client, folderName, FolderAccess.ReadOnly, cancellationToken);
+
+        if (folder.UidValidity != uidValidity)
+        {
+            _logger.LogWarning("UIDVALIDITY mismatch fetching attachment for {AccountId} {Folder}", accountId, folderName);
+            return null;
+        }
+
+        var message = await folder.GetMessageAsync(new UniqueId(uid), cancellationToken);
+        if (message is null) return null;
+
+        var parts = message.Attachments.OfType<MimePart>().ToList();
+        if (index >= parts.Count)
+        {
+            _logger.LogWarning("Attachment index {Index} out of range (have {Count})", index, parts.Count);
+            return null;
+        }
+
+        var part = parts[index];
+        using var ms = new MemoryStream();
+        await part.Content.DecodeToAsync(ms, cancellationToken);
+
+        return new EmailAttachmentContent
+        {
+            Name = part.FileName ?? "attachment",
+            ContentType = part.ContentType?.MimeType,
+            Bytes = ms.ToArray(),
+        };
+    }
+
     public async Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
@@ -492,13 +539,16 @@ public class ImapProviderService : IImapProviderService
         var from = m.From.Mailboxes.FirstOrDefault();
         var (body, format) = ExtractBody(m);
 
+        // IMAP has no native attachment IDs; use a positional synthetic id.
+        // Stable for the lifetime of the message structure on the server.
         var attachments = m.Attachments
             .OfType<MimePart>()
-            .Select(p => new EmailAttachment
+            .Select((p, i) => new EmailAttachment
             {
                 Name = p.FileName ?? "(unnamed)",
                 Size = p.Content?.Stream?.Length ?? 0,
-                ContentType = p.ContentType?.MimeType ?? "application/octet-stream"
+                ContentType = p.ContentType?.MimeType ?? "application/octet-stream",
+                AttachmentId = $"part-{i}",
             })
             .ToList();
 

--- a/src/CalendarMcp.Core/Providers/ImapProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/ImapProviderService.cs
@@ -274,7 +274,7 @@ public class ImapProviderService : IImapProviderService
     public async Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var cfg = await ResolveConfigAsync(accountId);

--- a/src/CalendarMcp.Core/Providers/ImapProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/ImapProviderService.cs
@@ -274,6 +274,7 @@ public class ImapProviderService : IImapProviderService
     public async Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var cfg = await ResolveConfigAsync(accountId);
@@ -288,10 +289,27 @@ public class ImapProviderService : IImapProviderService
                 message.Cc.Add(MailboxAddress.Parse(addr));
         }
         message.Subject = subject;
-        message.Body = new TextPart(bodyFormat?.Equals("text", StringComparison.OrdinalIgnoreCase) == true
-            ? TextFormat.Plain
-            : TextFormat.Html)
-        { Text = body };
+
+        if (attachments is { Count: > 0 })
+        {
+            var builder = new BodyBuilder();
+            if (bodyFormat?.Equals("text", StringComparison.OrdinalIgnoreCase) == true)
+                builder.TextBody = body;
+            else
+                builder.HtmlBody = body;
+
+            foreach (var att in attachments)
+                MimeAttachmentBuilder.Add(builder, att);
+
+            message.Body = builder.ToMessageBody();
+        }
+        else
+        {
+            message.Body = new TextPart(bodyFormat?.Equals("text", StringComparison.OrdinalIgnoreCase) == true
+                ? TextFormat.Plain
+                : TextFormat.Html)
+            { Text = body };
+        }
 
         using (var smtp = await OpenSmtpAsync(cfg, cancellationToken))
         {

--- a/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
@@ -420,7 +420,7 @@ public class JsonCalendarProviderService : IJsonCalendarProviderService
     public Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException("JSON file provider is read-only; emails cannot be sent.");
 

--- a/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
@@ -420,6 +420,7 @@ public class JsonCalendarProviderService : IJsonCalendarProviderService
     public Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException("JSON file provider is read-only; emails cannot be sent.");
 

--- a/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/JsonCalendarProviderService.cs
@@ -417,6 +417,11 @@ public class JsonCalendarProviderService : IJsonCalendarProviderService
         return entry == null ? null : MapToEmailMessage(entry, accountId);
     }
 
+    public Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId, string emailId, string attachmentId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<EmailAttachmentContent?>(null);
+
     public Task<string> SendEmailAsync(
         string accountId, string to, string subject, string body,
         string bodyFormat = "html", List<string>? cc = null,

--- a/src/CalendarMcp.Core/Providers/M365ProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/M365ProviderService.cs
@@ -254,6 +254,12 @@ public class M365ProviderService : IM365ProviderService
                 }
             }
 
+            var attachments = new List<EmailAttachment>();
+            if (message.HasAttachments == true)
+            {
+                attachments = await FetchAttachmentMetadataAsync(graphClient, emailId, cancellationToken);
+            }
+
             var result = new EmailMessage
             {
                 Id = message.Id ?? string.Empty,
@@ -268,6 +274,7 @@ public class M365ProviderService : IM365ProviderService
                 ReceivedDateTime = message.ReceivedDateTime?.DateTime ?? DateTime.MinValue,
                 IsRead = message.IsRead ?? false,
                 HasAttachments = message.HasAttachments ?? false,
+                Attachments = attachments,
                 UnsubscribeInfo = Utilities.UnsubscribeHeaderParser.Parse(listUnsubscribe, listUnsubscribePost)
             };
 
@@ -277,6 +284,76 @@ public class M365ProviderService : IM365ProviderService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting email details for {EmailId} from M365 account {AccountId}", emailId, accountId);
+            return null;
+        }
+    }
+
+    private static async Task<List<EmailAttachment>> FetchAttachmentMetadataAsync(
+        GraphServiceClient graphClient,
+        string emailId,
+        CancellationToken cancellationToken)
+    {
+        // Metadata only — exclude contentBytes to keep this cheap.
+        var page = await graphClient.Me.Messages[emailId].Attachments.GetAsync(
+            config => config.QueryParameters.Select = ["id", "name", "contentType", "size"],
+            cancellationToken);
+
+        var result = new List<EmailAttachment>();
+        if (page?.Value == null) return result;
+        foreach (var att in page.Value)
+        {
+            // ItemAttachments (forwarded messages) and ReferenceAttachments
+            // (links) are reported here too; we only surface FileAttachments.
+            if (att is not FileAttachment)
+                continue;
+            result.Add(new EmailAttachment
+            {
+                Name = att.Name ?? "attachment",
+                Size = att.Size ?? 0,
+                ContentType = att.ContentType ?? "application/octet-stream",
+                AttachmentId = att.Id,
+            });
+        }
+        return result;
+    }
+
+    public async Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId,
+        string emailId,
+        string attachmentId,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await GetAccessTokenAsync(accountId, cancellationToken);
+        if (token == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var authProvider = new BearerTokenAuthenticationProvider(token);
+            var graphClient = new GraphServiceClient(authProvider);
+
+            var attachment = await graphClient.Me.Messages[emailId].Attachments[attachmentId]
+                .GetAsync(cancellationToken: cancellationToken);
+
+            if (attachment is not FileAttachment file || file.ContentBytes == null)
+            {
+                _logger.LogWarning("Attachment {AttachmentId} on {EmailId} is not a file attachment", attachmentId, emailId);
+                return null;
+            }
+
+            return new EmailAttachmentContent
+            {
+                Name = file.Name ?? "attachment",
+                ContentType = file.ContentType,
+                Bytes = file.ContentBytes,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching attachment {AttachmentId} on {EmailId} from M365 account {AccountId}",
+                attachmentId, emailId, accountId);
             return null;
         }
     }

--- a/src/CalendarMcp.Core/Providers/M365ProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/M365ProviderService.cs
@@ -288,7 +288,7 @@ public class M365ProviderService : IM365ProviderService
         string body,
         string bodyFormat = "html",
         List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var token = await GetAccessTokenAsync(accountId, cancellationToken);

--- a/src/CalendarMcp.Core/Providers/M365ProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/M365ProviderService.cs
@@ -282,12 +282,13 @@ public class M365ProviderService : IM365ProviderService
     }
 
     public async Task<string> SendEmailAsync(
-        string accountId, 
-        string to, 
-        string subject, 
-        string body, 
-        string bodyFormat = "html", 
-        List<string>? cc = null, 
+        string accountId,
+        string to,
+        string subject,
+        string body,
+        string bodyFormat = "html",
+        List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var token = await GetAccessTokenAsync(accountId, cancellationToken);
@@ -335,6 +336,11 @@ public class M365ProviderService : IM365ProviderService
                     .ToList();
             }
 
+            if (attachments is { Count: > 0 })
+            {
+                message.Attachments = GraphAttachmentBuilder.Build(attachments);
+            }
+
             await graphClient.Me.SendMail.PostAsync(new SendMailPostRequestBody
             {
                 Message = message,
@@ -342,7 +348,7 @@ public class M365ProviderService : IM365ProviderService
             }, cancellationToken: cancellationToken);
 
             _logger.LogInformation("Email sent successfully from M365 account {AccountId} to {To}", accountId, to);
-            
+
             // SendMail doesn't return a message ID, so we return a confirmation
             return $"sent-{DateTime.UtcNow:yyyyMMddHHmmss}";
         }

--- a/src/CalendarMcp.Core/Providers/MimeAttachmentBuilder.cs
+++ b/src/CalendarMcp.Core/Providers/MimeAttachmentBuilder.cs
@@ -4,13 +4,13 @@ using MimeKit;
 namespace CalendarMcp.Core.Providers;
 
 /// <summary>
-/// Adds <see cref="EmailAttachment"/> entries to a MimeKit
+/// Adds <see cref="OutboundEmailAttachment"/> entries to a MimeKit
 /// <see cref="BodyBuilder"/>. Used by providers that compose outbound email
 /// as MIME (Gmail / IMAP-SMTP).
 /// </summary>
 internal static class MimeAttachmentBuilder
 {
-    public static void Add(BodyBuilder builder, EmailAttachment attachment)
+    public static void Add(BodyBuilder builder, OutboundEmailAttachment attachment)
     {
         if (string.IsNullOrWhiteSpace(attachment.Name))
             throw new ArgumentException("Attachment name is required.", nameof(attachment));

--- a/src/CalendarMcp.Core/Providers/MimeAttachmentBuilder.cs
+++ b/src/CalendarMcp.Core/Providers/MimeAttachmentBuilder.cs
@@ -1,0 +1,39 @@
+using CalendarMcp.Core.Models;
+using MimeKit;
+
+namespace CalendarMcp.Core.Providers;
+
+/// <summary>
+/// Adds <see cref="EmailAttachment"/> entries to a MimeKit
+/// <see cref="BodyBuilder"/>. Used by providers that compose outbound email
+/// as MIME (Gmail / IMAP-SMTP).
+/// </summary>
+internal static class MimeAttachmentBuilder
+{
+    public static void Add(BodyBuilder builder, EmailAttachment attachment)
+    {
+        if (string.IsNullOrWhiteSpace(attachment.Name))
+            throw new ArgumentException("Attachment name is required.", nameof(attachment));
+
+        byte[] bytes;
+        try
+        {
+            bytes = attachment.DecodeBytes();
+        }
+        catch (FormatException ex)
+        {
+            throw new ArgumentException(
+                $"Attachment '{attachment.Name}' has invalid base64 content.", nameof(attachment), ex);
+        }
+
+        if (!string.IsNullOrWhiteSpace(attachment.ContentType)
+            && ContentType.TryParse(attachment.ContentType, out var ct))
+        {
+            builder.Attachments.Add(attachment.Name, bytes, ct);
+        }
+        else
+        {
+            builder.Attachments.Add(attachment.Name, bytes);
+        }
+    }
+}

--- a/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
@@ -280,7 +280,7 @@ public class OutlookComProviderService : IOutlookComProviderService
         string body,
         string bodyFormat = "html",
         List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var token = await GetAccessTokenAsync(accountId, cancellationToken);

--- a/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
@@ -246,6 +246,12 @@ public class OutlookComProviderService : IOutlookComProviderService
                 }
             }
 
+            var attachments = new List<EmailAttachment>();
+            if (message.HasAttachments == true)
+            {
+                attachments = await FetchAttachmentMetadataAsync(graphClient, emailId, cancellationToken);
+            }
+
             var result = new EmailMessage
             {
                 Id = message.Id ?? string.Empty,
@@ -260,6 +266,7 @@ public class OutlookComProviderService : IOutlookComProviderService
                 ReceivedDateTime = message.ReceivedDateTime?.DateTime ?? DateTime.MinValue,
                 IsRead = message.IsRead ?? false,
                 HasAttachments = message.HasAttachments ?? false,
+                Attachments = attachments,
                 UnsubscribeInfo = Utilities.UnsubscribeHeaderParser.Parse(listUnsubscribe, listUnsubscribePost)
             };
 
@@ -269,6 +276,69 @@ public class OutlookComProviderService : IOutlookComProviderService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting email details for {EmailId} from Outlook.com account {AccountId}", emailId, accountId);
+            return null;
+        }
+    }
+
+    private static async Task<List<EmailAttachment>> FetchAttachmentMetadataAsync(
+        GraphServiceClient graphClient,
+        string emailId,
+        CancellationToken cancellationToken)
+    {
+        var page = await graphClient.Me.Messages[emailId].Attachments.GetAsync(
+            config => config.QueryParameters.Select = ["id", "name", "contentType", "size"],
+            cancellationToken);
+
+        var result = new List<EmailAttachment>();
+        if (page?.Value == null) return result;
+        foreach (var att in page.Value)
+        {
+            if (att is not FileAttachment) continue;
+            result.Add(new EmailAttachment
+            {
+                Name = att.Name ?? "attachment",
+                Size = att.Size ?? 0,
+                ContentType = att.ContentType ?? "application/octet-stream",
+                AttachmentId = att.Id,
+            });
+        }
+        return result;
+    }
+
+    public async Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId,
+        string emailId,
+        string attachmentId,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await GetAccessTokenAsync(accountId, cancellationToken);
+        if (token == null) return null;
+
+        try
+        {
+            var authProvider = new BearerTokenAuthenticationProvider(token);
+            var graphClient = new GraphServiceClient(authProvider);
+
+            var attachment = await graphClient.Me.Messages[emailId].Attachments[attachmentId]
+                .GetAsync(cancellationToken: cancellationToken);
+
+            if (attachment is not FileAttachment file || file.ContentBytes == null)
+            {
+                _logger.LogWarning("Attachment {AttachmentId} on {EmailId} is not a file attachment", attachmentId, emailId);
+                return null;
+            }
+
+            return new EmailAttachmentContent
+            {
+                Name = file.Name ?? "attachment",
+                ContentType = file.ContentType,
+                Bytes = file.ContentBytes,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching attachment {AttachmentId} on {EmailId} from Outlook.com account {AccountId}",
+                attachmentId, emailId, accountId);
             return null;
         }
     }

--- a/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/OutlookComProviderService.cs
@@ -274,12 +274,13 @@ public class OutlookComProviderService : IOutlookComProviderService
     }
 
     public async Task<string> SendEmailAsync(
-        string accountId, 
-        string to, 
-        string subject, 
-        string body, 
-        string bodyFormat = "html", 
-        List<string>? cc = null, 
+        string accountId,
+        string to,
+        string subject,
+        string body,
+        string bodyFormat = "html",
+        List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var token = await GetAccessTokenAsync(accountId, cancellationToken);
@@ -327,6 +328,11 @@ public class OutlookComProviderService : IOutlookComProviderService
                     .ToList();
             }
 
+            if (attachments is { Count: > 0 })
+            {
+                message.Attachments = GraphAttachmentBuilder.Build(attachments);
+            }
+
             await graphClient.Me.SendMail.PostAsync(new SendMailPostRequestBody
             {
                 Message = message,
@@ -334,7 +340,7 @@ public class OutlookComProviderService : IOutlookComProviderService
             }, cancellationToken: cancellationToken);
 
             _logger.LogInformation("Email sent successfully from Outlook.com account {AccountId} to {To}", accountId, to);
-            
+
             return $"sent-{DateTime.UtcNow:yyyyMMddHHmmss}";
         }
         catch (Exception ex)

--- a/src/CalendarMcp.Core/Services/IAttachmentStore.cs
+++ b/src/CalendarMcp.Core/Services/IAttachmentStore.cs
@@ -15,14 +15,29 @@ public interface IAttachmentStore
 
     /// <summary>
     /// Atomically removes and returns the entry. Returns <c>null</c> if the
-    /// ID is unknown or already expired.
+    /// ID is unknown or already expired. Use this for single-use consumption
+    /// paths (e.g. send_email).
     /// </summary>
     StoredAttachment? TryConsume(string attachmentId);
 
     /// <summary>
+    /// Returns the entry without removing it. Returns <c>null</c> if the ID
+    /// is unknown or expired. The entry remains in the store until consumed,
+    /// explicitly deleted, or TTL'd out. Use this for the HTTP GET path
+    /// where the caller may want to read first and consume later.
+    /// </summary>
+    StoredAttachment? TryRead(string attachmentId);
+
+    /// <summary>
+    /// Removes the entry if present. Returns true if removed, false if it
+    /// was already gone (or never existed). No-throw.
+    /// </summary>
+    bool TryDelete(string attachmentId);
+
+    /// <summary>
     /// Removes any entries past their absolute expiry. Safe to call from a
-    /// background sweeper; <see cref="TryConsume"/> also rejects expired
-    /// entries lazily.
+    /// background sweeper; <see cref="TryConsume"/> and <see cref="TryRead"/>
+    /// also reject expired entries lazily.
     /// </summary>
     void EvictExpired();
 }

--- a/src/CalendarMcp.Core/Services/IAttachmentStore.cs
+++ b/src/CalendarMcp.Core/Services/IAttachmentStore.cs
@@ -1,0 +1,44 @@
+namespace CalendarMcp.Core.Services;
+
+/// <summary>
+/// Server-side temporary store for binary attachments uploaded out-of-band by
+/// agents. Lets the <c>send_email</c> tool reference bytes by short ID instead
+/// of inlining a base64 payload in JSON tool arguments.
+/// </summary>
+public interface IAttachmentStore
+{
+    /// <summary>
+    /// Stores <paramref name="bytes"/> under a freshly generated ID.
+    /// Returns <c>null</c> if the global byte budget would be exceeded.
+    /// </summary>
+    StoredAttachment? Put(string name, string? contentType, byte[] bytes);
+
+    /// <summary>
+    /// Atomically removes and returns the entry. Returns <c>null</c> if the
+    /// ID is unknown or already expired.
+    /// </summary>
+    StoredAttachment? TryConsume(string attachmentId);
+
+    /// <summary>
+    /// Removes any entries past their absolute expiry. Safe to call from a
+    /// background sweeper; <see cref="TryConsume"/> also rejects expired
+    /// entries lazily.
+    /// </summary>
+    void EvictExpired();
+}
+
+public sealed class StoredAttachment
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public string? ContentType { get; init; }
+    public required byte[] Bytes { get; init; }
+    public required DateTimeOffset ExpiresAt { get; init; }
+}
+
+public sealed class AttachmentStoreOptions
+{
+    public int MaxBytesPerAttachment { get; set; } = 10 * 1024 * 1024;
+    public long MaxTotalBytes { get; set; } = 100L * 1024 * 1024;
+    public TimeSpan Ttl { get; set; } = TimeSpan.FromMinutes(15);
+}

--- a/src/CalendarMcp.Core/Services/IProviderService.cs
+++ b/src/CalendarMcp.Core/Services/IProviderService.cs
@@ -34,6 +34,7 @@ public interface IProviderService
         string body,
         string bodyFormat = "html",
         List<string>? cc = null,
+        IReadOnlyList<EmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default);
 
     Task DeleteEmailAsync(

--- a/src/CalendarMcp.Core/Services/IProviderService.cs
+++ b/src/CalendarMcp.Core/Services/IProviderService.cs
@@ -23,8 +23,21 @@ public interface IProviderService
         CancellationToken cancellationToken = default);
     
     Task<EmailMessage?> GetEmailDetailsAsync(
-        string accountId, 
+        string accountId,
         string emailId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the raw bytes of one attachment on a received email.
+    /// <paramref name="attachmentId"/> is the provider-side ID returned in
+    /// <see cref="EmailAttachment.AttachmentId"/> by
+    /// <see cref="GetEmailDetailsAsync"/>. Returns <c>null</c> if the
+    /// attachment isn't found or access fails.
+    /// </summary>
+    Task<EmailAttachmentContent?> GetEmailAttachmentContentAsync(
+        string accountId,
+        string emailId,
+        string attachmentId,
         CancellationToken cancellationToken = default);
     
     Task<string> SendEmailAsync(

--- a/src/CalendarMcp.Core/Services/IProviderService.cs
+++ b/src/CalendarMcp.Core/Services/IProviderService.cs
@@ -34,7 +34,7 @@ public interface IProviderService
         string body,
         string bodyFormat = "html",
         List<string>? cc = null,
-        IReadOnlyList<EmailAttachment>? attachments = null,
+        IReadOnlyList<OutboundEmailAttachment>? attachments = null,
         CancellationToken cancellationToken = default);
 
     Task DeleteEmailAsync(

--- a/src/CalendarMcp.Core/Services/InMemoryAttachmentStore.cs
+++ b/src/CalendarMcp.Core/Services/InMemoryAttachmentStore.cs
@@ -85,6 +85,42 @@ public sealed class InMemoryAttachmentStore : IAttachmentStore
         }
     }
 
+    public StoredAttachment? TryRead(string attachmentId)
+    {
+        if (string.IsNullOrEmpty(attachmentId))
+            return null;
+
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(attachmentId, out var entry))
+                return null;
+
+            if (entry.ExpiresAt <= _time.GetUtcNow())
+            {
+                // Lazily clean up the expired entry while we hold the lock.
+                _entries.Remove(attachmentId);
+                _totalBytes -= entry.Bytes.Length;
+                return null;
+            }
+
+            return entry;
+        }
+    }
+
+    public bool TryDelete(string attachmentId)
+    {
+        if (string.IsNullOrEmpty(attachmentId))
+            return false;
+
+        lock (_gate)
+        {
+            if (!_entries.Remove(attachmentId, out var entry))
+                return false;
+            _totalBytes -= entry.Bytes.Length;
+            return true;
+        }
+    }
+
     public void EvictExpired()
     {
         lock (_gate)

--- a/src/CalendarMcp.Core/Services/InMemoryAttachmentStore.cs
+++ b/src/CalendarMcp.Core/Services/InMemoryAttachmentStore.cs
@@ -1,0 +1,128 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CalendarMcp.Core.Services;
+
+/// <summary>
+/// Single-process attachment store backed by a dictionary. Suitable for the
+/// current single-pod deployment; switch to a distributed store if the
+/// HttpServer is ever scaled out.
+/// </summary>
+public sealed class InMemoryAttachmentStore : IAttachmentStore
+{
+    private readonly Dictionary<string, StoredAttachment> _entries = new(StringComparer.Ordinal);
+    private readonly Lock _gate = new();
+    private readonly AttachmentStoreOptions _options;
+    private readonly ILogger<InMemoryAttachmentStore> _logger;
+    private readonly TimeProvider _time;
+    private long _totalBytes;
+
+    public InMemoryAttachmentStore(
+        IOptions<AttachmentStoreOptions> options,
+        ILogger<InMemoryAttachmentStore> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _time = timeProvider ?? TimeProvider.System;
+    }
+
+    public StoredAttachment? Put(string name, string? contentType, byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        if (bytes.Length > _options.MaxBytesPerAttachment)
+        {
+            return null;
+        }
+
+        var id = NewId();
+        var entry = new StoredAttachment
+        {
+            Id = id,
+            Name = string.IsNullOrWhiteSpace(name) ? "attachment" : name,
+            ContentType = contentType,
+            Bytes = bytes,
+            ExpiresAt = _time.GetUtcNow().Add(_options.Ttl),
+        };
+
+        lock (_gate)
+        {
+            EvictExpiredCore();
+            if (_totalBytes + bytes.Length > _options.MaxTotalBytes)
+            {
+                return null;
+            }
+            _entries[id] = entry;
+            _totalBytes += bytes.Length;
+        }
+
+        _logger.LogDebug("Stored attachment {Id} ({Name}, {Size} bytes), expires {ExpiresAt:O}",
+            id, entry.Name, bytes.Length, entry.ExpiresAt);
+        return entry;
+    }
+
+    public StoredAttachment? TryConsume(string attachmentId)
+    {
+        if (string.IsNullOrEmpty(attachmentId))
+            return null;
+
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(attachmentId, out var entry))
+                return null;
+
+            _entries.Remove(attachmentId);
+            _totalBytes -= entry.Bytes.Length;
+
+            if (entry.ExpiresAt <= _time.GetUtcNow())
+            {
+                _logger.LogDebug("Attachment {Id} was past expiry on consume", attachmentId);
+                return null;
+            }
+
+            return entry;
+        }
+    }
+
+    public void EvictExpired()
+    {
+        lock (_gate)
+        {
+            EvictExpiredCore();
+        }
+    }
+
+    private void EvictExpiredCore()
+    {
+        var now = _time.GetUtcNow();
+        List<string>? toRemove = null;
+        foreach (var kv in _entries)
+        {
+            if (kv.Value.ExpiresAt <= now)
+            {
+                (toRemove ??= new List<string>()).Add(kv.Key);
+            }
+        }
+        if (toRemove == null) return;
+        foreach (var id in toRemove)
+        {
+            if (_entries.Remove(id, out var entry))
+            {
+                _totalBytes -= entry.Bytes.Length;
+            }
+        }
+        _logger.LogDebug("Evicted {Count} expired attachments", toRemove.Count);
+    }
+
+    // 16 random bytes -> 22-char base64url id.
+    private static string NewId()
+    {
+        Span<byte> buf = stackalloc byte[16];
+        RandomNumberGenerator.Fill(buf);
+        return Convert.ToBase64String(buf)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/CalendarMcp.Core/Tools/GetEmailAttachmentTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailAttachmentTool.cs
@@ -25,11 +25,11 @@ public sealed class GetEmailAttachmentTool(
     private const long InlineSizeLimitBytes = 1L * 1024 * 1024;
 
     [McpServerTool, Description(
-        "Fetch the bytes of one attachment on a received email. Use 'stash' mode (default) to put the bytes into the server's attachment store and get back an attachmentId you can immediately pass to send_email — bytes never round-trip through the agent. Use 'inline' mode only when the agent itself needs to read the content (e.g., to extract text from a PDF), and only for files under 1 MB. Required: accountId, emailId, attachmentId — get them from get_email_details.")]
+        "Fetch the bytes of one attachment on a received email. Required: accountId, emailId, attachmentId — get them from get_email_details. Modes: 'stash' (default) puts the bytes into the server's attachment store and returns an attachmentId you immediately pass to send_email; bytes never round-trip through the agent. 'inline' returns base64Content directly, capped at 1 MB; use when the agent itself needs to read the content (e.g., to extract text from a PDF). The stash attachmentId is consumed by send_email and is also readable via HTTP GET /attachments/{id} on the HTTP server (returns raw bytes; useful when the file exceeds the 1 MB inline cap and the agent has HTTP access). There is no MCP tool for downloading the stashed bytes — use the HTTP endpoint or just pass the ID to send_email.")]
     public async Task<string> GetEmailAttachment(
         [Description("Required. Account that owns the email.")] string accountId,
-        [Description("Required. Email message ID, from get_email_details.")] string emailId,
-        [Description("Required. Provider-side attachment ID, from the attachments[] array on get_email_details.")] string attachmentId,
+        [Description("Required. Email ID — pass as parameter name 'emailId' (NOT 'messageId'). Use the value from the 'id' field on get_email_details / get_emails / search_emails.")] string emailId,
+        [Description("Required. Provider-side attachment ID, from the attachments[] array on get_email_details (e.g. 'part-0' for Gmail/IMAP, an opaque string for Microsoft Graph).")] string attachmentId,
         [Description("'stash' (default) returns an attachmentId for use in send_email. 'inline' returns base64Content directly; capped at 1 MB.")] string mode = "stash")
     {
         if (string.IsNullOrEmpty(accountId)) return Err("accountId is required");

--- a/src/CalendarMcp.Core/Tools/GetEmailAttachmentTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailAttachmentTool.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel;
+using System.Text.Json;
+using CalendarMcp.Core.Services;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace CalendarMcp.Core.Tools;
+
+/// <summary>
+/// Fetches the bytes of one inbound email attachment. Defaults to "stash"
+/// mode: the server downloads from the upstream provider, drops the bytes
+/// into the same store used by the upload endpoint, and returns an
+/// attachmentId the agent can pass to <c>send_email</c>. The bytes never
+/// transit the LLM in that mode.
+/// </summary>
+[McpServerToolType]
+public sealed class GetEmailAttachmentTool(
+    IAccountRegistry accountRegistry,
+    IProviderServiceFactory providerFactory,
+    IAttachmentStore attachmentStore,
+    ILogger<GetEmailAttachmentTool> logger)
+{
+    // Hard cap on inline mode — anything larger forces the agent to use
+    // stash, which doesn't bloat the JSON tool result.
+    private const long InlineSizeLimitBytes = 1L * 1024 * 1024;
+
+    [McpServerTool, Description(
+        "Fetch the bytes of one attachment on a received email. Use 'stash' mode (default) to put the bytes into the server's attachment store and get back an attachmentId you can immediately pass to send_email — bytes never round-trip through the agent. Use 'inline' mode only when the agent itself needs to read the content (e.g., to extract text from a PDF), and only for files under 1 MB. Required: accountId, emailId, attachmentId — get them from get_email_details.")]
+    public async Task<string> GetEmailAttachment(
+        [Description("Required. Account that owns the email.")] string accountId,
+        [Description("Required. Email message ID, from get_email_details.")] string emailId,
+        [Description("Required. Provider-side attachment ID, from the attachments[] array on get_email_details.")] string attachmentId,
+        [Description("'stash' (default) returns an attachmentId for use in send_email. 'inline' returns base64Content directly; capped at 1 MB.")] string mode = "stash")
+    {
+        if (string.IsNullOrEmpty(accountId)) return Err("accountId is required");
+        if (string.IsNullOrEmpty(emailId)) return Err("emailId is required");
+        if (string.IsNullOrEmpty(attachmentId)) return Err("attachmentId is required");
+
+        var normalizedMode = mode?.Trim().ToLowerInvariant() ?? "stash";
+        if (normalizedMode is not ("stash" or "inline"))
+        {
+            return Err($"mode '{mode}' is invalid; use 'stash' or 'inline'.");
+        }
+
+        try
+        {
+            var account = await accountRegistry.GetAccountAsync(accountId);
+            if (account == null) return Err($"Account '{accountId}' not found");
+
+            var provider = providerFactory.GetProvider(account.Provider);
+            var content = await provider.GetEmailAttachmentContentAsync(
+                accountId, emailId, attachmentId, CancellationToken.None);
+
+            if (content == null)
+            {
+                return Err($"Attachment '{attachmentId}' on email '{emailId}' was not found or could not be fetched.");
+            }
+
+            if (normalizedMode == "inline")
+            {
+                if (content.Bytes.LongLength > InlineSizeLimitBytes)
+                {
+                    return Err(
+                        $"Attachment is {content.Bytes.LongLength:N0} bytes; inline mode is capped at {InlineSizeLimitBytes:N0} bytes. Re-call with mode='stash' and pass the returned attachmentId to send_email, or extract the bytes by other means.");
+                }
+                return JsonSerializer.Serialize(new
+                {
+                    name = content.Name,
+                    contentType = content.ContentType,
+                    size = content.Bytes.LongLength,
+                    base64Content = Convert.ToBase64String(content.Bytes),
+                });
+            }
+
+            // stash mode
+            var stored = attachmentStore.Put(content.Name, content.ContentType, content.Bytes);
+            if (stored == null)
+            {
+                return Err(
+                    $"Could not stash the attachment ({content.Bytes.LongLength:N0} bytes); the attachment is over the per-attachment cap or the store is full. Try inline mode if the file is small.");
+            }
+
+            logger.LogInformation(
+                "Stashed inbound attachment {AttachmentId} from {EmailId} as {StoreId} ({Size} bytes)",
+                attachmentId, emailId, stored.Id, stored.Bytes.Length);
+
+            return JsonSerializer.Serialize(new
+            {
+                attachmentId = stored.Id,
+                name = stored.Name,
+                contentType = stored.ContentType,
+                size = stored.Bytes.LongLength,
+                expiresAt = stored.ExpiresAt,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error in get_email_attachment tool");
+            return Err("Failed to fetch attachment", ex.Message);
+        }
+    }
+
+    private static string Err(string error, string? detail = null)
+        => detail == null
+            ? JsonSerializer.Serialize(new { error })
+            : JsonSerializer.Serialize(new { error, detail });
+}

--- a/src/CalendarMcp.Core/Tools/GetEmailDetailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailDetailsTool.cs
@@ -79,7 +79,8 @@ public sealed class GetEmailDetailsTool(
                 {
                     name = a.Name,
                     size = a.Size,
-                    contentType = a.ContentType
+                    contentType = a.ContentType,
+                    attachmentId = a.AttachmentId,
                 })
             };
 

--- a/src/CalendarMcp.Core/Tools/GetEmailDetailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailDetailsTool.cs
@@ -18,7 +18,7 @@ public sealed class GetEmailDetailsTool(
     [McpServerTool, Description("Get full email content including body and attachments for a specific email. Both accountId and emailId are required — obtain them from the accountId and id fields returned by get_emails or search_emails.")]
     public async Task<string> GetEmailDetails(
         [Description("Required. Account ID that owns the email. Obtain from the accountId field returned by get_emails or search_emails.")] string accountId,
-        [Description("Required. Email message ID. Obtain from the id field returned by get_emails or search_emails.")] string emailId)
+        [Description("Required. Email ID — pass as parameter name 'emailId' (NOT 'messageId'). Use the value from the 'id' field returned by get_emails or search_emails.")] string emailId)
     {
         logger.LogInformation("Getting email details: accountId={AccountId}, emailId={EmailId}",
             accountId, emailId);

--- a/src/CalendarMcp.Core/Tools/SendEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/SendEmailTool.cs
@@ -28,7 +28,7 @@ public sealed class SendEmailTool(
         [Description("Account ID to send from. Omit to use smart routing (matches recipient domain to account domains, then falls back to first account). Obtain from list_accounts.")] string? accountId = null,
         [Description("Body content format: 'html' (default) or 'text'")] string bodyFormat = "html",
         [Description("CC recipient email addresses")] List<string>? cc = null,
-        [Description("Optional file attachments as a JSON array. Each item: {\"name\":\"report.pdf\",\"contentType\":\"application/pdf\",\"base64Content\":\"<base64-encoded bytes>\"}. contentType is optional. Total payload across all attachments must stay under 25 MB; Microsoft 365 and Outlook.com cap each attachment at 3 MB.")] List<EmailAttachment>? attachments = null)
+        [Description("Optional file attachments as a JSON array. Each item: {\"name\":\"report.pdf\",\"contentType\":\"application/pdf\",\"base64Content\":\"<base64-encoded bytes>\"}. contentType is optional. Total payload across all attachments must stay under 25 MB; Microsoft 365 and Outlook.com cap each attachment at 3 MB.")] List<OutboundEmailAttachment>? attachments = null)
     {
         // Strip CDATA wrappers if present (LLMs sometimes wrap content in XML CDATA)
         body = StripCdataWrapper(body);
@@ -143,7 +143,7 @@ public sealed class SendEmailTool(
         }
     }
 
-    private static string? ValidateAttachments(List<EmailAttachment> attachments)
+    private static string? ValidateAttachments(List<OutboundEmailAttachment> attachments)
     {
         long total = 0;
         for (var i = 0; i < attachments.Count; i++)

--- a/src/CalendarMcp.Core/Tools/SendEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/SendEmailTool.cs
@@ -14,6 +14,7 @@ namespace CalendarMcp.Core.Tools;
 public sealed class SendEmailTool(
     IAccountRegistry accountRegistry,
     IProviderServiceFactory providerFactory,
+    IAttachmentStore attachmentStore,
     ILogger<SendEmailTool> logger)
 {
     // Total decoded attachment payload limit per message. Keeps the JSON tool
@@ -28,7 +29,7 @@ public sealed class SendEmailTool(
         [Description("Account ID to send from. Omit to use smart routing (matches recipient domain to account domains, then falls back to first account). Obtain from list_accounts.")] string? accountId = null,
         [Description("Body content format: 'html' (default) or 'text'")] string bodyFormat = "html",
         [Description("CC recipient email addresses")] List<string>? cc = null,
-        [Description("Optional file attachments as a JSON array. Each item: {\"name\":\"report.pdf\",\"contentType\":\"application/pdf\",\"base64Content\":\"<base64-encoded bytes>\"}. contentType is optional. Total payload across all attachments must stay under 25 MB; Microsoft 365 and Outlook.com cap each attachment at 3 MB.")] List<OutboundEmailAttachment>? attachments = null)
+        [Description("Optional file attachments as a JSON array. Each item must set EITHER \"attachmentId\" (preferred for anything non-trivial: upload the file via POST /attachments first to get the ID) OR \"base64Content\" (the raw bytes encoded as base64; use only for very small files). \"name\" is required when using base64Content and optional when using attachmentId. \"contentType\" is optional. Total decoded payload per message must stay under 25 MB; Microsoft 365 and Outlook.com cap each individual attachment at 3 MB. Examples: [{\"attachmentId\":\"AbCd...\"}] or [{\"name\":\"x.pdf\",\"base64Content\":\"...\"}].")] List<OutboundEmailAttachment>? attachments = null)
     {
         // Strip CDATA wrappers if present (LLMs sometimes wrap content in XML CDATA)
         body = StripCdataWrapper(body);
@@ -41,13 +42,24 @@ public sealed class SendEmailTool(
             });
         }
 
+        List<OutboundEmailAttachment>? resolvedAttachments = null;
         if (attachments is { Count: > 0 })
         {
-            var validationError = ValidateAttachments(attachments);
-            if (validationError != null)
+            var shapeError = ValidateAttachmentShapes(attachments);
+            if (shapeError != null)
             {
-                return JsonSerializer.Serialize(new { error = validationError });
+                return JsonSerializer.Serialize(new { error = shapeError });
             }
+
+            // Second pass: consume any AttachmentId-backed entries. From this
+            // point on, IDs are removed from the store; an error after this
+            // requires the agent to re-upload.
+            var (resolved, consumeError) = ResolveAttachments(attachments);
+            if (consumeError != null)
+            {
+                return JsonSerializer.Serialize(new { error = consumeError });
+            }
+            resolvedAttachments = resolved;
         }
 
         var toJoined = string.Join(", ", to);
@@ -114,7 +126,7 @@ public sealed class SendEmailTool(
             // Send email
             var provider = providerFactory.GetProvider(account.Provider);
             var messageId = await provider.SendEmailAsync(
-                account.Id, toJoined, subject, body, bodyFormat, cc, attachments, CancellationToken.None);
+                account.Id, toJoined, subject, body, bodyFormat, cc, resolvedAttachments, CancellationToken.None);
 
             var result = new
             {
@@ -143,32 +155,90 @@ public sealed class SendEmailTool(
         }
     }
 
-    private static string? ValidateAttachments(List<OutboundEmailAttachment> attachments)
+    /// <summary>
+    /// First pass: structural validation only. Does NOT touch the attachment
+    /// store. Returns an error string for the caller, or null if all items are
+    /// well-formed.
+    /// </summary>
+    private static string? ValidateAttachmentShapes(List<OutboundEmailAttachment> attachments)
     {
-        long total = 0;
+        long inlineEstimatedBytes = 0;
         for (var i = 0; i < attachments.Count; i++)
         {
             var att = attachments[i];
-            if (string.IsNullOrWhiteSpace(att.Name))
+            var hasInline = !string.IsNullOrEmpty(att.Base64Content);
+            var hasId = !string.IsNullOrEmpty(att.AttachmentId);
+
+            if (hasInline && hasId)
             {
-                return $"attachments[{i}].name is required.";
+                return $"attachments[{i}]: set either 'base64Content' or 'attachmentId', not both.";
             }
-            if (string.IsNullOrEmpty(att.Base64Content))
+            if (!hasInline && !hasId)
             {
-                return $"attachments[{i}].base64Content is required for '{att.Name}'.";
+                return $"attachments[{i}]: set either 'base64Content' (inline bytes) or 'attachmentId' (from POST /attachments).";
             }
-            // Cheap size estimate from the base64 string length, no allocation.
-            // Each 4 base64 chars decode to up to 3 bytes; this overestimates by
-            // up to 2 bytes per attachment, which is fine for the 25 MB cap.
-            var len = att.Base64Content.Length;
-            var estimatedBytes = (long)(len / 4) * 3;
-            total += estimatedBytes;
-            if (total > MaxTotalAttachmentBytes)
+            if (hasInline && string.IsNullOrWhiteSpace(att.Name))
             {
-                return $"Total attachment size exceeds {MaxTotalAttachmentBytes:N0} bytes.";
+                return $"attachments[{i}].name is required when using base64Content.";
+            }
+            if (hasInline)
+            {
+                // Cheap size estimate from base64 length; overestimates by up
+                // to 2 bytes per attachment, which is fine for the 25 MB cap.
+                var len = att.Base64Content!.Length;
+                inlineEstimatedBytes += (long)(len / 4) * 3;
+                if (inlineEstimatedBytes > MaxTotalAttachmentBytes)
+                {
+                    return $"Total inline attachment size exceeds {MaxTotalAttachmentBytes:N0} bytes.";
+                }
             }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Second pass: resolves any <see cref="OutboundEmailAttachment.AttachmentId"/>
+    /// entries to inline bytes by consuming them from the store. Single-use:
+    /// successfully consumed IDs are removed, so an error after this point
+    /// requires the agent to re-upload.
+    /// </summary>
+    private (List<OutboundEmailAttachment>? resolved, string? error) ResolveAttachments(
+        List<OutboundEmailAttachment> attachments)
+    {
+        var result = new List<OutboundEmailAttachment>(attachments.Count);
+        long totalBytes = 0;
+
+        for (var i = 0; i < attachments.Count; i++)
+        {
+            var att = attachments[i];
+
+            if (!string.IsNullOrEmpty(att.AttachmentId))
+            {
+                var stored = attachmentStore.TryConsume(att.AttachmentId);
+                if (stored == null)
+                {
+                    return (null, $"attachments[{i}]: attachmentId '{att.AttachmentId}' is unknown or expired. Re-upload via POST /attachments.");
+                }
+                totalBytes += stored.Bytes.Length;
+                if (totalBytes > MaxTotalAttachmentBytes)
+                {
+                    return (null, $"Total attachment size exceeds {MaxTotalAttachmentBytes:N0} bytes.");
+                }
+                result.Add(new OutboundEmailAttachment
+                {
+                    Name = string.IsNullOrWhiteSpace(att.Name) ? stored.Name : att.Name,
+                    ContentType = att.ContentType ?? stored.ContentType,
+                    Base64Content = Convert.ToBase64String(stored.Bytes),
+                });
+            }
+            else
+            {
+                // Inline base64 — already validated by ValidateAttachmentShapes.
+                result.Add(att);
+            }
+        }
+
+        return (result, null);
     }
 
     /// <summary>

--- a/src/CalendarMcp.Core/Tools/SendEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/SendEmailTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -15,14 +16,19 @@ public sealed class SendEmailTool(
     IProviderServiceFactory providerFactory,
     ILogger<SendEmailTool> logger)
 {
-    [McpServerTool, Description("Send an email. If accountId is omitted, smart routing selects the account whose domains match the first recipient's email domain; if no match, the first configured account is used. Provide accountId explicitly to guarantee which account sends the message.")]
+    // Total decoded attachment payload limit per message. Keeps the JSON tool
+    // call within agent limits and matches typical provider caps (~25 MB).
+    private const long MaxTotalAttachmentBytes = 25L * 1024 * 1024;
+
+    [McpServerTool, Description("Send an email, optionally with file attachments. If accountId is omitted, smart routing selects the account whose domains match the first recipient's email domain; if no match, the first configured account is used. Provide accountId explicitly to guarantee which account sends the message.")]
     public async Task<string> SendEmail(
         [Description("Recipient email address(es). Supply as a JSON array of strings, e.g. [\"alice@example.com\"] or [\"alice@example.com\",\"bob@example.com\"].")] List<string> to,
         [Description("Email subject line")] string subject,
         [Description("Email body content. Use HTML when bodyFormat is 'html' (the default).")] string body,
         [Description("Account ID to send from. Omit to use smart routing (matches recipient domain to account domains, then falls back to first account). Obtain from list_accounts.")] string? accountId = null,
         [Description("Body content format: 'html' (default) or 'text'")] string bodyFormat = "html",
-        [Description("CC recipient email addresses")] List<string>? cc = null)
+        [Description("CC recipient email addresses")] List<string>? cc = null,
+        [Description("Optional file attachments as a JSON array. Each item: {\"name\":\"report.pdf\",\"contentType\":\"application/pdf\",\"base64Content\":\"<base64-encoded bytes>\"}. contentType is optional. Total payload across all attachments must stay under 25 MB; Microsoft 365 and Outlook.com cap each attachment at 3 MB.")] List<EmailAttachment>? attachments = null)
     {
         // Strip CDATA wrappers if present (LLMs sometimes wrap content in XML CDATA)
         body = StripCdataWrapper(body);
@@ -33,6 +39,15 @@ public sealed class SendEmailTool(
             {
                 error = "At least one recipient address is required in the 'to' field."
             });
+        }
+
+        if (attachments is { Count: > 0 })
+        {
+            var validationError = ValidateAttachments(attachments);
+            if (validationError != null)
+            {
+                return JsonSerializer.Serialize(new { error = validationError });
+            }
         }
 
         var toJoined = string.Join(", ", to);
@@ -99,7 +114,7 @@ public sealed class SendEmailTool(
             // Send email
             var provider = providerFactory.GetProvider(account.Provider);
             var messageId = await provider.SendEmailAsync(
-                account.Id, toJoined, subject, body, bodyFormat, cc, CancellationToken.None);
+                account.Id, toJoined, subject, body, bodyFormat, cc, attachments, CancellationToken.None);
 
             var result = new
             {
@@ -126,6 +141,34 @@ public sealed class SendEmailTool(
                 inner = ex.InnerException?.Message
             });
         }
+    }
+
+    private static string? ValidateAttachments(List<EmailAttachment> attachments)
+    {
+        long total = 0;
+        for (var i = 0; i < attachments.Count; i++)
+        {
+            var att = attachments[i];
+            if (string.IsNullOrWhiteSpace(att.Name))
+            {
+                return $"attachments[{i}].name is required.";
+            }
+            if (string.IsNullOrEmpty(att.Base64Content))
+            {
+                return $"attachments[{i}].base64Content is required for '{att.Name}'.";
+            }
+            // Cheap size estimate from the base64 string length, no allocation.
+            // Each 4 base64 chars decode to up to 3 bytes; this overestimates by
+            // up to 2 bytes per attachment, which is fine for the 25 MB cap.
+            var len = att.Base64Content.Length;
+            var estimatedBytes = (long)(len / 4) * 3;
+            total += estimatedBytes;
+            if (total > MaxTotalAttachmentBytes)
+            {
+                return $"Total attachment size exceeds {MaxTotalAttachmentBytes:N0} bytes.";
+            }
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/CalendarMcp.Core/Tools/UnsubscribeFromEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/UnsubscribeFromEmailTool.cs
@@ -172,7 +172,7 @@ public sealed class UnsubscribeFromEmailTool(
         try
         {
             var (to, subject, body) = parsed.Value;
-            await provider.SendEmailAsync(account.Id, to, subject, body, "text", null, CancellationToken.None);
+            await provider.SendEmailAsync(account.Id, to, subject, body, "text", null, null, CancellationToken.None);
 
             return new Models.UnsubscribeResult
             {

--- a/src/CalendarMcp.HttpServer/Endpoints/AttachmentEndpoints.cs
+++ b/src/CalendarMcp.HttpServer/Endpoints/AttachmentEndpoints.cs
@@ -18,7 +18,50 @@ public static class AttachmentEndpoints
             .ProducesProblem(StatusCodes.Status413PayloadTooLarge)
             .ProducesProblem(StatusCodes.Status507InsufficientStorage);
 
+        group.MapGet("/{attachmentId}", DownloadAsync)
+            .WithName("DownloadAttachment")
+            .WithSummary("Read the bytes of a stored attachment without consuming it. Entry remains in the store until send_email consumes it, DELETE removes it, or TTL expires.")
+            .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapDelete("/{attachmentId}", DeleteAsync)
+            .WithName("DeleteAttachment")
+            .WithSummary("Remove an attachment from the store before its TTL.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return routes;
+    }
+
+    private static IResult DownloadAsync(
+        string attachmentId,
+        IAttachmentStore store)
+    {
+        var entry = store.TryRead(attachmentId);
+        if (entry == null)
+        {
+            return Results.Problem(
+                title: "Attachment not found",
+                detail: "The attachment ID is unknown, expired, or was already consumed by send_email.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return Results.File(
+            entry.Bytes,
+            contentType: entry.ContentType ?? "application/octet-stream",
+            fileDownloadName: entry.Name);
+    }
+
+    private static IResult DeleteAsync(
+        string attachmentId,
+        IAttachmentStore store)
+    {
+        return store.TryDelete(attachmentId)
+            ? Results.NoContent()
+            : Results.Problem(
+                title: "Attachment not found",
+                detail: "Nothing to delete; the attachment ID is unknown, expired, or was already consumed.",
+                statusCode: StatusCodes.Status404NotFound);
     }
 
     private static async Task<IResult> UploadAsync(

--- a/src/CalendarMcp.HttpServer/Endpoints/AttachmentEndpoints.cs
+++ b/src/CalendarMcp.HttpServer/Endpoints/AttachmentEndpoints.cs
@@ -1,0 +1,97 @@
+using CalendarMcp.Core.Services;
+
+namespace CalendarMcp.HttpServer.Endpoints;
+
+public static class AttachmentEndpoints
+{
+    public static IEndpointRouteBuilder MapAttachmentEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/attachments")
+            .WithTags("Attachments")
+            .DisableAntiforgery();
+
+        group.MapPost("/", UploadAsync)
+            .WithName("UploadAttachment")
+            .WithSummary("Upload a binary attachment for use in send_email.")
+            .Produces<UploadResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status413PayloadTooLarge)
+            .ProducesProblem(StatusCodes.Status507InsufficientStorage);
+
+        return routes;
+    }
+
+    private static async Task<IResult> UploadAsync(
+        HttpRequest request,
+        IAttachmentStore store,
+        ILogger<InMemoryAttachmentStore> logger,
+        CancellationToken cancellationToken)
+    {
+        if (!request.HasFormContentType)
+        {
+            return Results.Problem(
+                title: "Multipart form-data required",
+                detail: "POST a multipart/form-data body with exactly one file part.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        IFormCollection form;
+        try
+        {
+            form = await request.ReadFormAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem(
+                title: "Invalid multipart body",
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (form.Files.Count != 1)
+        {
+            return Results.Problem(
+                title: "Exactly one file required",
+                detail: $"Got {form.Files.Count} file parts; expected 1.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var file = form.Files[0];
+
+        // Read into memory; per-attachment cap is enforced by the store.
+        using var ms = new MemoryStream();
+        await file.CopyToAsync(ms, cancellationToken);
+        var bytes = ms.ToArray();
+
+        var stored = store.Put(file.FileName, file.ContentType, bytes);
+        if (stored == null)
+        {
+            // Store rejected: either over per-attachment cap or global cap.
+            // We can't tell which without more API surface; report the more
+            // common one (per-attachment) when the file is itself oversized.
+            logger.LogWarning("Attachment upload rejected: name={Name}, size={Size}", file.FileName, bytes.Length);
+            if (bytes.Length > 10 * 1024 * 1024)
+            {
+                return Results.Problem(
+                    title: "Attachment too large",
+                    detail: "Each upload must be 10 MB or less.",
+                    statusCode: StatusCodes.Status413PayloadTooLarge);
+            }
+            return Results.Problem(
+                title: "Attachment store full",
+                detail: "Server attachment cache is at capacity. Try again in a few minutes.",
+                statusCode: StatusCodes.Status507InsufficientStorage);
+        }
+
+        return Results.Created(
+            $"/attachments/{stored.Id}",
+            new UploadResponse(stored.Id, stored.Name, stored.ContentType, bytes.Length, stored.ExpiresAt));
+    }
+
+    public sealed record UploadResponse(
+        string AttachmentId,
+        string Name,
+        string? ContentType,
+        long Size,
+        DateTimeOffset ExpiresAt);
+}

--- a/src/CalendarMcp.HttpServer/Endpoints/AttachmentEvictionService.cs
+++ b/src/CalendarMcp.HttpServer/Endpoints/AttachmentEvictionService.cs
@@ -1,0 +1,39 @@
+using CalendarMcp.Core.Services;
+
+namespace CalendarMcp.HttpServer.Endpoints;
+
+/// <summary>
+/// Periodically removes expired entries from <see cref="IAttachmentStore"/>.
+/// Without this the store would still reject expired entries on consume, but
+/// memory would only be reclaimed when an upload triggered the lazy sweep.
+/// </summary>
+public sealed class AttachmentEvictionService(
+    IAttachmentStore store,
+    ILogger<AttachmentEvictionService> logger) : BackgroundService
+{
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(60);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Attachment eviction sweeper started, interval {Interval}", SweepInterval);
+        using var timer = new PeriodicTimer(SweepInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                try
+                {
+                    store.EvictExpired();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Attachment eviction sweep failed; will retry");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+    }
+}

--- a/src/CalendarMcp.HttpServer/Program.cs
+++ b/src/CalendarMcp.HttpServer/Program.cs
@@ -131,6 +131,7 @@ public class Program
             .WithTools<CalendarMcp.Core.Tools.ListAccountsTool>()
             .WithTools<CalendarMcp.Core.Tools.GetEmailsTool>()
             .WithTools<CalendarMcp.Core.Tools.GetEmailDetailsTool>()
+            .WithTools<CalendarMcp.Core.Tools.GetEmailAttachmentTool>()
             .WithTools<CalendarMcp.Core.Tools.SearchEmailsTool>()
             .WithTools<CalendarMcp.Core.Tools.SendEmailTool>()
             .WithTools<CalendarMcp.Core.Tools.DeleteEmailTool>()

--- a/src/CalendarMcp.HttpServer/Program.cs
+++ b/src/CalendarMcp.HttpServer/Program.cs
@@ -3,6 +3,7 @@ using CalendarMcp.Auth;
 using CalendarMcp.Core.Configuration;
 using CalendarMcp.HttpServer.Admin;
 using CalendarMcp.HttpServer.BlazorAdmin;
+using CalendarMcp.HttpServer.Endpoints;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -100,6 +101,10 @@ public class Program
         builder.Services.AddSingleton<IAccountConfigurationService, AccountConfigurationService>();
         builder.Services.AddSingleton<DeviceCodeAuthManager>();
         builder.Services.AddSingleton<GoogleOAuthManager>();
+
+        // Background sweeper for the attachment store (uploads land here only
+        // in HTTP mode, so eviction is HTTP-side too).
+        builder.Services.AddHostedService<AttachmentEvictionService>();
 
         // OpenAPI
         builder.Services.AddOpenApi();
@@ -202,6 +207,10 @@ public class Program
 
         // Map MCP protocol endpoints (HTTP/SSE)
         app.MapMcp();
+
+        // Map attachment upload endpoint (sibling of /mcp; same network-level
+        // protection — Tailscale ACLs / reverse proxy).
+        app.MapAttachmentEndpoints();
 
         // Map admin API endpoints
         app.MapAdminEndpoints();

--- a/src/CalendarMcp.StdioServer/Program.cs
+++ b/src/CalendarMcp.StdioServer/Program.cs
@@ -117,6 +117,7 @@ public class Program
                     .WithTools<CalendarMcp.Core.Tools.ListAccountsTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailsTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailDetailsTool>()
+                    .WithTools<CalendarMcp.Core.Tools.GetEmailAttachmentTool>()
                     .WithTools<CalendarMcp.Core.Tools.SearchEmailsTool>()
                     .WithTools<CalendarMcp.Core.Tools.SendEmailTool>()
                     .WithTools<CalendarMcp.Core.Tools.DeleteEmailTool>()

--- a/src/CalendarMcp.Tests/Helpers/TestAttachmentStore.cs
+++ b/src/CalendarMcp.Tests/Helpers/TestAttachmentStore.cs
@@ -1,0 +1,49 @@
+using CalendarMcp.Core.Services;
+
+namespace CalendarMcp.Tests.Helpers;
+
+/// <summary>
+/// Minimal in-memory <see cref="IAttachmentStore"/> for tests. Lets tests
+/// pre-populate entries with <see cref="Seed"/> and asserts via
+/// <see cref="ConsumedIds"/>.
+/// </summary>
+public sealed class TestAttachmentStore : IAttachmentStore
+{
+    private readonly Dictionary<string, StoredAttachment> _entries = new(StringComparer.Ordinal);
+    public List<string> ConsumedIds { get; } = new();
+
+    public StoredAttachment Seed(
+        string id,
+        string name,
+        byte[] bytes,
+        string? contentType = null,
+        DateTimeOffset? expiresAt = null)
+    {
+        var entry = new StoredAttachment
+        {
+            Id = id,
+            Name = name,
+            ContentType = contentType,
+            Bytes = bytes,
+            ExpiresAt = expiresAt ?? DateTimeOffset.UtcNow.AddMinutes(15),
+        };
+        _entries[id] = entry;
+        return entry;
+    }
+
+    public StoredAttachment? Put(string name, string? contentType, byte[] bytes)
+    {
+        // Tests don't go through the upload path; force them to use Seed.
+        throw new NotImplementedException("Use Seed in tests.");
+    }
+
+    public StoredAttachment? TryConsume(string attachmentId)
+    {
+        ConsumedIds.Add(attachmentId);
+        if (!_entries.Remove(attachmentId, out var entry))
+            return null;
+        return entry.ExpiresAt <= DateTimeOffset.UtcNow ? null : entry;
+    }
+
+    public void EvictExpired() { /* no-op for tests */ }
+}

--- a/src/CalendarMcp.Tests/Helpers/TestAttachmentStore.cs
+++ b/src/CalendarMcp.Tests/Helpers/TestAttachmentStore.cs
@@ -45,5 +45,15 @@ public sealed class TestAttachmentStore : IAttachmentStore
         return entry.ExpiresAt <= DateTimeOffset.UtcNow ? null : entry;
     }
 
+    public StoredAttachment? TryRead(string attachmentId)
+    {
+        if (!_entries.TryGetValue(attachmentId, out var entry))
+            return null;
+        return entry.ExpiresAt <= DateTimeOffset.UtcNow ? null : entry;
+    }
+
+    public bool TryDelete(string attachmentId)
+        => _entries.Remove(attachmentId);
+
     public void EvictExpired() { /* no-op for tests */ }
 }

--- a/src/CalendarMcp.Tests/Services/InMemoryAttachmentStoreTests.cs
+++ b/src/CalendarMcp.Tests/Services/InMemoryAttachmentStoreTests.cs
@@ -79,6 +79,61 @@ public class InMemoryAttachmentStoreTests
     }
 
     [TestMethod]
+    public void TryRead_DoesNotConsume_AndIsRepeatable()
+    {
+        var store = CreateStore();
+        var stored = store.Put("a.txt", "text/plain", "hello"u8.ToArray());
+        Assert.IsNotNull(stored);
+
+        var first = store.TryRead(stored!.Id);
+        var second = store.TryRead(stored.Id);
+        Assert.IsNotNull(first);
+        Assert.IsNotNull(second);
+        CollectionAssert.AreEqual(first!.Bytes, second!.Bytes);
+
+        // Subsequent consume still works since read didn't remove the entry.
+        var consumed = store.TryConsume(stored.Id);
+        Assert.IsNotNull(consumed);
+
+        // After consume, both Read and Consume should miss.
+        Assert.IsNull(store.TryRead(stored.Id));
+        Assert.IsNull(store.TryConsume(stored.Id));
+    }
+
+    [TestMethod]
+    public void TryDelete_RemovesEntry_AndFreesQuota()
+    {
+        var store = CreateStore(new AttachmentStoreOptions { MaxTotalBytes = 100 });
+        var stored = store.Put("a", null, new byte[80]);
+        Assert.IsNotNull(stored);
+
+        Assert.IsTrue(store.TryDelete(stored!.Id));
+        Assert.IsFalse(store.TryDelete(stored.Id));   // already gone
+        Assert.IsNull(store.TryRead(stored.Id));
+
+        // Quota was freed: a fresh 80 B upload now fits where the 80 B + 80 B
+        // collision would have failed.
+        Assert.IsNotNull(store.Put("b", null, new byte[80]));
+    }
+
+    [TestMethod]
+    public void TryRead_ExpiredEntry_ReturnsNullAndEvicts()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var store = CreateStore(
+            new AttachmentStoreOptions { Ttl = TimeSpan.FromMinutes(1), MaxTotalBytes = 100 },
+            time);
+
+        var stored = store.Put("a", null, new byte[80]);
+        Assert.IsNotNull(stored);
+        time.Advance(TimeSpan.FromMinutes(2));
+
+        Assert.IsNull(store.TryRead(stored!.Id));
+        // Read should have evicted lazily; quota is reclaimed.
+        Assert.IsNotNull(store.Put("b", null, new byte[80]));
+    }
+
+    [TestMethod]
     public void EvictExpired_RemovesPastEntriesAndFreesQuota()
     {
         var time = new FakeTimeProvider(DateTimeOffset.UtcNow);

--- a/src/CalendarMcp.Tests/Services/InMemoryAttachmentStoreTests.cs
+++ b/src/CalendarMcp.Tests/Services/InMemoryAttachmentStoreTests.cs
@@ -1,0 +1,111 @@
+using CalendarMcp.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace CalendarMcp.Tests.Services;
+
+[TestClass]
+public class InMemoryAttachmentStoreTests
+{
+    private static InMemoryAttachmentStore CreateStore(
+        AttachmentStoreOptions? options = null,
+        TimeProvider? time = null)
+    {
+        return new InMemoryAttachmentStore(
+            Options.Create(options ?? new AttachmentStoreOptions()),
+            NullLogger<InMemoryAttachmentStore>.Instance,
+            time);
+    }
+
+    [TestMethod]
+    public void Put_Then_TryConsume_RoundTripsBytes()
+    {
+        var store = CreateStore();
+        var data = "hello"u8.ToArray();
+
+        var stored = store.Put("hello.txt", "text/plain", data);
+
+        Assert.IsNotNull(stored);
+        Assert.IsFalse(string.IsNullOrEmpty(stored!.Id));
+        Assert.AreEqual("hello.txt", stored.Name);
+        Assert.AreEqual("text/plain", stored.ContentType);
+        CollectionAssert.AreEqual(data, stored.Bytes);
+
+        var consumed = store.TryConsume(stored.Id);
+        Assert.IsNotNull(consumed);
+        CollectionAssert.AreEqual(data, consumed!.Bytes);
+
+        // Single-use: a second consume returns null.
+        Assert.IsNull(store.TryConsume(stored.Id));
+    }
+
+    [TestMethod]
+    public void Put_RejectsOversizedFile()
+    {
+        var store = CreateStore(new AttachmentStoreOptions { MaxBytesPerAttachment = 100 });
+        var stored = store.Put("big.bin", null, new byte[101]);
+        Assert.IsNull(stored);
+    }
+
+    [TestMethod]
+    public void Put_RejectsWhenGlobalCapWouldBeExceeded()
+    {
+        var store = CreateStore(new AttachmentStoreOptions
+        {
+            MaxBytesPerAttachment = 1000,
+            MaxTotalBytes = 100,
+        });
+
+        Assert.IsNotNull(store.Put("a", null, new byte[60]));
+        // Next 60 bytes would put us at 120, over the 100-byte global cap.
+        Assert.IsNull(store.Put("b", null, new byte[60]));
+    }
+
+    [TestMethod]
+    public void TryConsume_ExpiredEntry_ReturnsNull()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var store = CreateStore(
+            new AttachmentStoreOptions { Ttl = TimeSpan.FromMinutes(1) },
+            time);
+
+        var stored = store.Put("x", null, new byte[10]);
+        Assert.IsNotNull(stored);
+
+        time.Advance(TimeSpan.FromMinutes(2));
+
+        var consumed = store.TryConsume(stored!.Id);
+        Assert.IsNull(consumed);
+    }
+
+    [TestMethod]
+    public void EvictExpired_RemovesPastEntriesAndFreesQuota()
+    {
+        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var store = CreateStore(
+            new AttachmentStoreOptions
+            {
+                Ttl = TimeSpan.FromMinutes(1),
+                MaxTotalBytes = 100,
+                MaxBytesPerAttachment = 100,
+            },
+            time);
+
+        var first = store.Put("a", null, new byte[80]);
+        Assert.IsNotNull(first);
+
+        time.Advance(TimeSpan.FromMinutes(2));
+        store.EvictExpired();
+
+        // Quota should be reclaimed: a fresh 80-byte upload now fits.
+        var second = store.Put("b", null, new byte[80]);
+        Assert.IsNotNull(second);
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+}

--- a/src/CalendarMcp.Tests/Tools/GetEmailAttachmentToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetEmailAttachmentToolTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using CalendarMcp.Core.Models;
+using CalendarMcp.Core.Services;
+using CalendarMcp.Core.Tools;
+using CalendarMcp.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Rocks;
+
+namespace CalendarMcp.Tests.Tools;
+
+[TestClass]
+public class GetEmailAttachmentToolTests
+{
+    [TestMethod]
+    public async Task StashMode_DefaultsAndStoresInAttachmentStore()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var bytes = "PDF-content"u8.ToArray();
+        var (regExp, factExp, provExp) = WireProviderForFetch(
+            account, "msg-1", "graph-att-1",
+            new EmailAttachmentContent { Name = "report.pdf", ContentType = "application/pdf", Bytes = bytes });
+
+        var store = new InMemoryAttachmentStore(
+            Options.Create(new AttachmentStoreOptions()),
+            NullLogger<InMemoryAttachmentStore>.Instance);
+
+        var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(), store,
+            NullLogger<GetEmailAttachmentTool>.Instance);
+
+        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "graph-att-1");
+
+        var doc = JsonDocument.Parse(json).RootElement;
+        var newId = doc.GetProperty("attachmentId").GetString()!;
+        Assert.IsFalse(string.IsNullOrEmpty(newId));
+        Assert.AreEqual("report.pdf", doc.GetProperty("name").GetString());
+        Assert.AreEqual("application/pdf", doc.GetProperty("contentType").GetString());
+        Assert.AreEqual(bytes.Length, doc.GetProperty("size").GetInt64());
+
+        // The store should now have the bytes under the returned ID,
+        // ready to feed into send_email.
+        var stored = store.TryConsume(newId);
+        Assert.IsNotNull(stored);
+        CollectionAssert.AreEqual(bytes, stored!.Bytes);
+
+        regExp.Verify();
+        factExp.Verify();
+        provExp.Verify();
+    }
+
+    [TestMethod]
+    public async Task InlineMode_UnderCap_ReturnsBase64()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var bytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+        var (regExp, factExp, _) = WireProviderForFetch(
+            account, "msg-1", "att-1",
+            new EmailAttachmentContent { Name = "x.bin", ContentType = "application/octet-stream", Bytes = bytes });
+
+        var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
+
+        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "inline");
+
+        var doc = JsonDocument.Parse(json).RootElement;
+        Assert.AreEqual("x.bin", doc.GetProperty("name").GetString());
+        CollectionAssert.AreEqual(bytes,
+            Convert.FromBase64String(doc.GetProperty("base64Content").GetString()!));
+    }
+
+    [TestMethod]
+    public async Task InlineMode_OverCap_ReturnsError()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        // 2 MB > 1 MB inline cap.
+        var bytes = new byte[2 * 1024 * 1024];
+        var (regExp, factExp, _) = WireProviderForFetch(
+            account, "msg-1", "att-1",
+            new EmailAttachmentContent { Name = "big.bin", ContentType = null, Bytes = bytes });
+
+        var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
+
+        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "inline");
+        var error = JsonDocument.Parse(json).RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("inline mode is capped", StringComparison.Ordinal) ?? false);
+        Assert.IsTrue(error?.Contains("stash", StringComparison.Ordinal) ?? false);
+    }
+
+    [TestMethod]
+    public async Task ProviderReturnsNull_BubblesAsError()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var (regExp, factExp, _) = WireProviderForFetch(account, "msg-1", "missing", null);
+
+        var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
+
+        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "missing");
+        var error = JsonDocument.Parse(json).RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("not found", StringComparison.Ordinal) ?? false);
+    }
+
+    [TestMethod]
+    public async Task InvalidMode_ReturnsError()
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
+
+        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "weird");
+        var error = JsonDocument.Parse(json).RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("invalid", StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private static (
+        IAccountRegistryCreateExpectations reg,
+        IProviderServiceFactoryCreateExpectations fact,
+        IProviderServiceCreateExpectations prov) WireProviderForFetch(
+            AccountInfo account,
+            string emailId,
+            string attachmentId,
+            EmailAttachmentContent? content)
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync(account.Id)
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        var provExp = new IProviderServiceCreateExpectations();
+        provExp.Setups.GetEmailAttachmentContentAsync(
+            account.Id, emailId, attachmentId, Arg.Any<CancellationToken>())
+            .ReturnValue(Task.FromResult(content));
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        factExp.Setups.GetProvider(account.Provider).ReturnValue(provExp.Instance());
+
+        return (regExp, factExp, provExp);
+    }
+}

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolAttachmentIdTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolAttachmentIdTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using CalendarMcp.Core.Models;
+using CalendarMcp.Core.Services;
+using CalendarMcp.Core.Tools;
+using CalendarMcp.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rocks;
+
+namespace CalendarMcp.Tests.Tools;
+
+[TestClass]
+public class SendEmailToolAttachmentIdTests
+{
+    [TestMethod]
+    public async Task SendEmail_ResolvesAttachmentIdToBytes_AndConsumesEntry()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var bytes = "PDF-content"u8.ToArray();
+        var store = new TestAttachmentStore();
+        store.Seed("upload-id-1", "report.pdf", bytes, "application/pdf");
+
+        IReadOnlyList<OutboundEmailAttachment>? captured = null;
+        var (regExp, factExp, provExp) = WireProvider(account, atts => captured = atts);
+
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(), store,
+            NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<OutboundEmailAttachment>
+            {
+                new() { AttachmentId = "upload-id-1" },
+            });
+
+        Assert.IsTrue(JsonDocument.Parse(result).RootElement.GetProperty("success").GetBoolean());
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(1, captured!.Count);
+        Assert.AreEqual("report.pdf", captured[0].Name);
+        Assert.AreEqual("application/pdf", captured[0].ContentType);
+        CollectionAssert.AreEqual(bytes, Convert.FromBase64String(captured[0].Base64Content!));
+
+        // Single-use: store consumed the entry.
+        CollectionAssert.AreEqual(new[] { "upload-id-1" }, store.ConsumedIds);
+
+        regExp.Verify();
+        factExp.Verify();
+        provExp.Verify();
+    }
+
+    [TestMethod]
+    public async Task SendEmail_InlineNameAndContentTypeOverrideUploadMetadata()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var store = new TestAttachmentStore();
+        store.Seed("u1", "uploaded.bin", new byte[] { 1, 2, 3 }, "application/octet-stream");
+
+        IReadOnlyList<OutboundEmailAttachment>? captured = null;
+        var (regExp, factExp, provExp) = WireProvider(account, atts => captured = atts);
+
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(), store,
+            NullLogger<SendEmailTool>.Instance);
+
+        await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<OutboundEmailAttachment>
+            {
+                new()
+                {
+                    AttachmentId = "u1",
+                    Name = "renamed.dat",
+                    ContentType = "application/x-custom",
+                },
+            });
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("renamed.dat", captured![0].Name);
+        Assert.AreEqual("application/x-custom", captured[0].ContentType);
+    }
+
+    [TestMethod]
+    public async Task SendEmail_UnknownAttachmentId_ReturnsError()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync("acc-1")
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        // Provider should NOT be called.
+
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<OutboundEmailAttachment>
+            {
+                new() { AttachmentId = "does-not-exist" },
+            });
+
+        var error = JsonDocument.Parse(result).RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("does-not-exist", StringComparison.Ordinal) ?? false);
+        Assert.IsTrue(error?.Contains("unknown or expired", StringComparison.Ordinal) ?? false);
+    }
+
+    [TestMethod]
+    public async Task SendEmail_BothInlineAndId_ReturnsError_AndDoesNotConsume()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var store = new TestAttachmentStore();
+        store.Seed("u1", "x.bin", new byte[] { 1 });
+
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(), store,
+            NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<OutboundEmailAttachment>
+            {
+                new() { AttachmentId = "u1", Name = "x.bin", Base64Content = "AQ==" },
+            });
+
+        var error = JsonDocument.Parse(result).RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("not both", StringComparison.OrdinalIgnoreCase) ?? false);
+
+        // Store entry must NOT have been consumed — shape errors precede consumption.
+        Assert.AreEqual(0, store.ConsumedIds.Count);
+    }
+
+    [TestMethod]
+    public async Task SendEmail_NeitherInlineNorId_ReturnsError()
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<OutboundEmailAttachment>
+            {
+                new() { Name = "x.bin" },
+            });
+
+        var error = JsonDocument.Parse(result).RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("base64Content", StringComparison.Ordinal) ?? false);
+        Assert.IsTrue(error?.Contains("attachmentId", StringComparison.Ordinal) ?? false);
+    }
+
+    private static (
+        IAccountRegistryCreateExpectations reg,
+        IProviderServiceFactoryCreateExpectations fact,
+        IProviderServiceCreateExpectations prov) WireProvider(
+            AccountInfo account,
+            Action<IReadOnlyList<OutboundEmailAttachment>?> capture)
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync(account.Id)
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        var provExp = new IProviderServiceCreateExpectations();
+        provExp.Setups.SendEmailAsync(
+            account.Id, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<List<string>?>(),
+            Arg.Any<IReadOnlyList<OutboundEmailAttachment>?>(),
+            Arg.Any<CancellationToken>())
+            .Callback((string _, string _, string _, string _, string _,
+                       List<string>? _, IReadOnlyList<OutboundEmailAttachment>? atts,
+                       CancellationToken _) =>
+            {
+                capture(atts);
+                return Task.FromResult("msg-1");
+            });
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        factExp.Setups.GetProvider(account.Provider).ReturnValue(provExp.Instance());
+
+        return (regExp, factExp, provExp);
+    }
+}

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolMcpInvocationTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolMcpInvocationTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using CalendarMcp.Core.Models;
+using CalendarMcp.Core.Services;
+using CalendarMcp.Core.Tools;
+using CalendarMcp.Tests.Helpers;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rocks;
+
+namespace CalendarMcp.Tests.Tools;
+
+/// <summary>
+/// Verifies that the MCP SDK's AIFunctionFactory can deserialize a JSON
+/// argument payload containing a complex attachment array into the tool
+/// method's <see cref="OutboundEmailAttachment"/> parameter. Direct C# calls
+/// in <see cref="SendEmailToolTests"/> bypass that path; this test exercises
+/// the same wiring used at runtime by McpServerTool.Create + InvokeAsync.
+/// </summary>
+[TestClass]
+public class SendEmailToolMcpInvocationTests
+{
+    [TestMethod]
+    public async Task SendEmail_InvokedThroughMcpFactory_DeserializesAttachmentJson()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync("acc-1")
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        IReadOnlyList<OutboundEmailAttachment>? capturedAttachments = null;
+
+        var provExp = new IProviderServiceCreateExpectations();
+        provExp.Setups.SendEmailAsync(
+            "acc-1", "to@example.com", "Subject", "Body", Arg.Any<string>(),
+            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<OutboundEmailAttachment>?>(),
+            Arg.Any<CancellationToken>())
+            .Callback((string _, string _, string _, string _, string _,
+                       List<string>? _, IReadOnlyList<OutboundEmailAttachment>? atts,
+                       CancellationToken _) =>
+            {
+                capturedAttachments = atts;
+                return Task.FromResult("msg-123");
+            });
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        factExp.Setups.GetProvider("microsoft365").ReturnValue(provExp.Instance());
+
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
+
+        // Build an AIFunction the same way the MCP SDK does internally
+        // (McpServerTool wraps AIFunctionFactory.Create).
+        var method = typeof(SendEmailTool).GetMethod(nameof(SendEmailTool.SendEmail))!;
+        var aiFunction = AIFunctionFactory.Create(method, tool);
+
+        // Compose the JSON arguments an MCP client would send.
+        var argumentsJson = """
+        {
+            "to": ["to@example.com"],
+            "subject": "Subject",
+            "body": "Body",
+            "accountId": "acc-1",
+            "attachments": [
+                {
+                    "name": "hello.txt",
+                    "contentType": "text/plain",
+                    "base64Content": "aGVsbG8="
+                }
+            ]
+        }
+        """;
+
+        var args = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(argumentsJson)!;
+        var aiArgs = new AIFunctionArguments();
+        foreach (var kv in args)
+            aiArgs[kv.Key] = kv.Value;
+
+        var result = await aiFunction.InvokeAsync(aiArgs, CancellationToken.None);
+
+        Assert.IsNotNull(result, "AIFunction returned null");
+
+        // The provider should have received exactly one attachment with the
+        // decoded payload that came in over JSON.
+        Assert.IsNotNull(capturedAttachments, "Provider was never called");
+        Assert.AreEqual(1, capturedAttachments!.Count);
+        Assert.AreEqual("hello.txt", capturedAttachments[0].Name);
+        Assert.AreEqual("text/plain", capturedAttachments[0].ContentType);
+        Assert.AreEqual("aGVsbG8=", capturedAttachments[0].Base64Content);
+
+        regExp.Verify();
+        factExp.Verify();
+        provExp.Verify();
+    }
+}

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
@@ -23,7 +23,8 @@ public class SendEmailToolTests
         var provExp = new IProviderServiceCreateExpectations();
         provExp.Setups.SendEmailAsync(
             "acc-1", "to@example.com", "Subject", "Body", Arg.Any<string>(),
-            Arg.Any<List<string>?>(), Arg.Any<CancellationToken>())
+            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<EmailAttachment>?>(),
+            Arg.Any<CancellationToken>())
             .ReturnValue(Task.FromResult("msg-123"));
 
         var factExp = new IProviderServiceFactoryCreateExpectations();
@@ -92,5 +93,108 @@ public class SendEmailToolTests
 
         var error = doc.RootElement.GetProperty("error").GetString();
         Assert.IsTrue(error?.Contains("recipient", StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    [TestMethod]
+    public async Task SendEmail_WithAttachment_PassesThroughToProvider()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync("acc-1")
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        var provExp = new IProviderServiceCreateExpectations();
+        provExp.Setups.SendEmailAsync(
+            "acc-1", "to@example.com", "Subject", "Body", Arg.Any<string>(),
+            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<EmailAttachment>?>(),
+            Arg.Any<CancellationToken>())
+            .ReturnValue(Task.FromResult("msg-123"));
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        factExp.Setups.GetProvider("microsoft365").ReturnValue(provExp.Instance());
+
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<SendEmailTool>.Instance);
+
+        var attachment = new EmailAttachment
+        {
+            Name = "hello.txt",
+            ContentType = "text/plain",
+            Base64Content = Convert.ToBase64String("hello"u8.ToArray()),
+        };
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<EmailAttachment> { attachment });
+
+        var doc = JsonDocument.Parse(result);
+        Assert.IsTrue(doc.RootElement.GetProperty("success").GetBoolean());
+
+        regExp.Verify();
+        factExp.Verify();
+        provExp.Verify();
+    }
+
+    [TestMethod]
+    public async Task SendEmail_AttachmentMissingName_ReturnsError()
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<EmailAttachment>
+            {
+                new() { Name = "", Base64Content = "aGVsbG8=" },
+            });
+
+        var doc = JsonDocument.Parse(result);
+        var error = doc.RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("name is required", StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    [TestMethod]
+    public async Task SendEmail_AttachmentMissingContent_ReturnsError()
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<SendEmailTool>.Instance);
+
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<EmailAttachment>
+            {
+                new() { Name = "x.txt", Base64Content = "" },
+            });
+
+        var doc = JsonDocument.Parse(result);
+        var error = doc.RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("base64Content", StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    [TestMethod]
+    public async Task SendEmail_AttachmentExceedsTotalCap_ReturnsError()
+    {
+        var regExp = new IAccountRegistryCreateExpectations();
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<SendEmailTool>.Instance);
+
+        // 35 MB of base64 chars decodes to ~26 MB, just over the 25 MB cap.
+        var bigBase64 = new string('A', 35 * 1024 * 1024);
+        var result = await tool.SendEmail(
+            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+            attachments: new List<EmailAttachment>
+            {
+                new() { Name = "a.bin", Base64Content = bigBase64 },
+            });
+
+        var doc = JsonDocument.Parse(result);
+        var error = doc.RootElement.GetProperty("error").GetString();
+        Assert.IsTrue(error?.Contains("exceeds", StringComparison.OrdinalIgnoreCase) ?? false);
     }
 }

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
@@ -23,7 +23,7 @@ public class SendEmailToolTests
         var provExp = new IProviderServiceCreateExpectations();
         provExp.Setups.SendEmailAsync(
             "acc-1", "to@example.com", "Subject", "Body", Arg.Any<string>(),
-            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<EmailAttachment>?>(),
+            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<OutboundEmailAttachment>?>(),
             Arg.Any<CancellationToken>())
             .ReturnValue(Task.FromResult("msg-123"));
 
@@ -107,7 +107,7 @@ public class SendEmailToolTests
         var provExp = new IProviderServiceCreateExpectations();
         provExp.Setups.SendEmailAsync(
             "acc-1", "to@example.com", "Subject", "Body", Arg.Any<string>(),
-            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<EmailAttachment>?>(),
+            Arg.Any<List<string>?>(), Arg.Any<IReadOnlyList<OutboundEmailAttachment>?>(),
             Arg.Any<CancellationToken>())
             .ReturnValue(Task.FromResult("msg-123"));
 
@@ -117,7 +117,7 @@ public class SendEmailToolTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SendEmailTool>.Instance);
 
-        var attachment = new EmailAttachment
+        var attachment = new OutboundEmailAttachment
         {
             Name = "hello.txt",
             ContentType = "text/plain",
@@ -126,7 +126,7 @@ public class SendEmailToolTests
 
         var result = await tool.SendEmail(
             new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<EmailAttachment> { attachment });
+            attachments: new List<OutboundEmailAttachment> { attachment });
 
         var doc = JsonDocument.Parse(result);
         Assert.IsTrue(doc.RootElement.GetProperty("success").GetBoolean());
@@ -146,7 +146,7 @@ public class SendEmailToolTests
 
         var result = await tool.SendEmail(
             new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<EmailAttachment>
+            attachments: new List<OutboundEmailAttachment>
             {
                 new() { Name = "", Base64Content = "aGVsbG8=" },
             });
@@ -166,7 +166,7 @@ public class SendEmailToolTests
 
         var result = await tool.SendEmail(
             new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<EmailAttachment>
+            attachments: new List<OutboundEmailAttachment>
             {
                 new() { Name = "x.txt", Base64Content = "" },
             });
@@ -188,7 +188,7 @@ public class SendEmailToolTests
         var bigBase64 = new string('A', 35 * 1024 * 1024);
         var result = await tool.SendEmail(
             new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<EmailAttachment>
+            attachments: new List<OutboundEmailAttachment>
             {
                 new() { Name = "a.bin", Base64Content = bigBase64 },
             });

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
@@ -31,7 +31,7 @@ public class SendEmailToolTests
         factExp.Setups.GetProvider("microsoft365").ReturnValue(provExp.Instance());
 
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var result = await tool.SendEmail(new List<string> { "to@example.com" }, "Subject", "Body", "acc-1");
         var doc = JsonDocument.Parse(result);
@@ -53,7 +53,7 @@ public class SendEmailToolTests
 
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var result = await tool.SendEmail(new List<string> { "to@example.com" }, "Subject", "Body", "nonexistent");
         var doc = JsonDocument.Parse(result);
@@ -71,7 +71,7 @@ public class SendEmailToolTests
 
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var result = await tool.SendEmail(new List<string> { "to@unknown.com" }, "Subject", "Body");
         var doc = JsonDocument.Parse(result);
@@ -86,7 +86,7 @@ public class SendEmailToolTests
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var result = await tool.SendEmail([], "Subject", "Body", "acc-1");
         var doc = JsonDocument.Parse(result);
@@ -115,7 +115,7 @@ public class SendEmailToolTests
         factExp.Setups.GetProvider("microsoft365").ReturnValue(provExp.Instance());
 
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var attachment = new OutboundEmailAttachment
         {
@@ -142,7 +142,7 @@ public class SendEmailToolTests
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var result = await tool.SendEmail(
             new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
@@ -162,7 +162,7 @@ public class SendEmailToolTests
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         var result = await tool.SendEmail(
             new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
@@ -182,7 +182,7 @@ public class SendEmailToolTests
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
-            NullLogger<SendEmailTool>.Instance);
+            new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
         // 35 MB of base64 chars decodes to ~26 MB, just over the 25 MB cap.
         var bigBase64 = new string('A', 35 * 1024 * 1024);


### PR DESCRIPTION
End-to-end email attachment support across all real email providers (M365,
Outlook.com, Gmail, IMAP/SMTP). Started as outbound-only; grew through
several review iterations into a complete inbound + outbound + temp-store
solution that's been validated against rockbot in the live k8s deployment.

## What ships

**Outbound** (the original PR):
- `send_email` accepts an `attachments` array per item with either
  `base64Content` (inline) or `attachmentId` (from upload).
- All four real providers attach via the right API: Graph
  `FileAttachment` (M365/Outlook.com), MimeKit `BodyBuilder` + base64url
  raw send (Gmail), MimeKit + SMTP (IMAP). ICS and JSON providers
  throw `NotSupportedException`.
- Per-message cap 25 MB; per-attachment 3 MB on Graph.

**Upload endpoint**:
- `POST /attachments` (multipart) returns
  `{ attachmentId, name, contentType, size, expiresAt }`.
- `GET /attachments/{id}` non-consuming read (raw bytes,
  `Content-Disposition`).
- `DELETE /attachments/{id}` explicit cleanup.
- `IAttachmentStore` interface + `InMemoryAttachmentStore`: 22-char
  base64url IDs from `RandomNumberGenerator`, single-use consume on
  `send_email`, multi-read on GET, 60 s background eviction sweeper.
- Limits: 10 MB per upload, 100 MB global, 15 min TTL. In-process memory
  only — no PVC required for the single-pod deployment.

**Inbound attachment visibility + fetch**:
- `get_email_details` populates an `attachments[]` array with name, size,
  contentType, and a provider-side `attachmentId`. Implemented for
  M365, Outlook.com, Gmail, and IMAP. ICS/JSON return `null`.
- New `get_email_attachment` tool fetches by ID. Two modes:
  - `stash` (default): bytes go straight into `IAttachmentStore`,
    returns the store ID; agent passes that ID to `send_email` to
    forward without bytes ever transiting the LLM.
  - `inline`: returns `base64Content` directly; capped at 1 MB.
- Gmail uses positional `part-N` IDs (handles small inline-data
  attachments and large separate-fetch attachments uniformly). IMAP also
  positional. Graph uses native opaque IDs.

## What changed during review

- Original design assumed agents could either base64-encode files or
  share a filesystem with the server. Neither is true for hosted agents
  (M365 Copilot) or k8s-deployed servers without PVCs. The HTTP upload
  endpoint addresses this.
- Initial agent self-test (rockbot) tripped over the missing
  `GET /attachments/{id}` and burned tool calls guessing URL shapes.
  Added GET/DELETE for symmetry.
- Tool descriptions tightened: `emailId` parameter explicitly says "NOT
  messageId" after agents fumbled it; `get_email_attachment` description
  mentions the HTTP GET endpoint as the escape hatch when the file is
  too large for the 1 MB inline cap.
- Gmail attachment fetch initially used Gmail's `body.attachmentId`,
  which doesn't behave for small inline-data attachments. Switched to
  positional `part-N`.

## Testing

- 243/243 unit tests pass. New coverage:
  - `InMemoryAttachmentStoreTests` (8): put/consume, oversized rejection,
    global cap, expiry on consume, expiry on read, eviction frees quota,
    peek-twice, delete frees quota.
  - `SendEmailToolTests` + `SendEmailToolMcpInvocationTests` (9): direct
    invocation and full `AIFunctionFactory` round-trip with attachment
    JSON.
  - `SendEmailToolAttachmentIdTests` (5): ID resolution, name/contentType
    overrides, unknown ID, both-shapes rejection, neither-shape
    rejection.
  - `GetEmailAttachmentToolTests` (5): stash mode round-trips bytes
    through the store; inline under cap returns base64; inline over cap
    rejects with guidance to use stash; provider-null bubbles as error;
    invalid mode rejects.
- End-to-end manual validation in the live k8s deployment:
  - Outbound: rockbot sent attachments via base64 path (succeeded) and
    via `POST /attachments` upload + `attachmentId` flow.
  - Inbound: rockbot fetched a 58-byte text attachment from a Gmail
    message via both `inline` and `stash` modes (after the Gmail
    inline-data fix in 1.2.5).
  - HTTP store lifecycle: rockbot's Python script verified
    POST → GET → DELETE → GET-404 round trip.

## Deployment

Image `rockylhotka/calendar-mcp-http:1.2.6` already deployed and tested
in the cluster.

## Known limitations

- Single-replica only. The in-memory store is per-pod; if HttpServer is
  ever scaled out, swap `InMemoryAttachmentStore` for a Redis-backed
  implementation. Interface stays the same.
- Pod restart drops in-flight uploads. Acceptable given 15 min TTL and
  re-upload-on-retry. PVC would survive restart but adds operational
  surface for marginal benefit at this scale.
- Graph `ItemAttachment` (forwarded-message attachments) and
  `ReferenceAttachment` (links) are intentionally excluded from inbound
  visibility — only `FileAttachment` is surfaced.
- IMAP/Gmail attachment IDs are positional (`part-N`); fine in practice
  since agents fetch right after listing details.
- No agent-facing streaming. MCP protocol delivers tool results as a
  single JSON-RPC message even over SSE. Server-internal forward
  streaming is a future option (would skip the store entirely for
  forward workflows; requires Graph upload sessions for outbound > 3 MB).

## Discoverability follow-up

Filed #53 for the unrelated M365/Outlook `\$search` quote-handling bug
noticed in the rockbot logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)