### PR TITLE
Throw McpException for tool errors instead of success-with-error-body

### DIFF
--- a/src/CalendarMcp.Core/Tools/BulkDeleteEmailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/BulkDeleteEmailsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -25,27 +26,21 @@ public sealed class BulkDeleteEmailsTool(
     {
         logger.LogInformation("Bulk deleting emails");
 
+        if (items == null || items.Length == 0)
+            throw new McpException("items array must not be empty");
+
+        if (items.Length > MaxBatchSize)
+            throw new McpException($"Batch size {items.Length} exceeds maximum of {MaxBatchSize}");
+
+        // Validate all items have required fields
+        foreach (var item in items)
+        {
+            if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
+                throw new McpException("Each item must have 'accountId' and 'emailId' fields");
+        }
+
         try
         {
-            if (items == null || items.Length == 0)
-            {
-                return JsonSerializer.Serialize(new { error = "items array must not be empty" });
-            }
-
-            if (items.Length > MaxBatchSize)
-            {
-                return JsonSerializer.Serialize(new { error = $"Batch size {items.Length} exceeds maximum of {MaxBatchSize}" });
-            }
-
-            // Validate all items have required fields
-            foreach (var item in items)
-            {
-                if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
-                {
-                    return JsonSerializer.Serialize(new { error = "Each item must have 'accountId' and 'emailId' fields" });
-                }
-            }
-
             // Resolve accounts once per unique accountId
             var accounts = await ResolveAccountsAsync(items);
 
@@ -65,7 +60,8 @@ public sealed class BulkDeleteEmailsTool(
                 }
                 catch (Exception ex)
                 {
-                    return new BulkResultItem(item.EmailId, item.AccountId, false, ex.Message);
+                    logger.LogError(ex, "Error deleting email {EmailId} in account {AccountId}", item.EmailId, item.AccountId);
+                    return new BulkResultItem(item.EmailId, item.AccountId, false, "Failed to delete email.");
                 }
                 finally
                 {
@@ -89,10 +85,10 @@ public sealed class BulkDeleteEmailsTool(
                     : new { r.EmailId, r.AccountId, r.Success, error = r.Error })
             }, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in bulk_delete_emails tool");
-            return JsonSerializer.Serialize(new { error = "Failed to bulk delete emails", message = ex.Message });
+            throw new McpException("Failed to bulk delete emails.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/BulkMarkEmailsAsReadTool.cs
+++ b/src/CalendarMcp.Core/Tools/BulkMarkEmailsAsReadTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -26,27 +27,21 @@ public sealed class BulkMarkEmailsAsReadTool(
     {
         logger.LogInformation("Bulk marking emails as {ReadStatus}", isRead ? "read" : "unread");
 
+        if (items == null || items.Length == 0)
+            throw new McpException("items array must not be empty");
+
+        if (items.Length > MaxBatchSize)
+            throw new McpException($"Batch size {items.Length} exceeds maximum of {MaxBatchSize}");
+
+        // Validate all items have required fields
+        foreach (var item in items)
+        {
+            if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
+                throw new McpException("Each item must have 'accountId' and 'emailId' fields");
+        }
+
         try
         {
-            if (items == null || items.Length == 0)
-            {
-                return JsonSerializer.Serialize(new { error = "items array must not be empty" });
-            }
-
-            if (items.Length > MaxBatchSize)
-            {
-                return JsonSerializer.Serialize(new { error = $"Batch size {items.Length} exceeds maximum of {MaxBatchSize}" });
-            }
-
-            // Validate all items have required fields
-            foreach (var item in items)
-            {
-                if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
-                {
-                    return JsonSerializer.Serialize(new { error = "Each item must have 'accountId' and 'emailId' fields" });
-                }
-            }
-
             // Resolve accounts once per unique accountId
             var accounts = await ResolveAccountsAsync(items);
 
@@ -66,7 +61,8 @@ public sealed class BulkMarkEmailsAsReadTool(
                 }
                 catch (Exception ex)
                 {
-                    return new BulkResultItem(item.EmailId, item.AccountId, false, ex.Message);
+                    logger.LogError(ex, "Error marking email {EmailId} in account {AccountId}", item.EmailId, item.AccountId);
+                    return new BulkResultItem(item.EmailId, item.AccountId, false, "Failed to mark email.");
                 }
                 finally
                 {
@@ -91,10 +87,10 @@ public sealed class BulkMarkEmailsAsReadTool(
                     : new { r.EmailId, r.AccountId, r.Success, error = r.Error })
             }, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in bulk_mark_emails_as_read tool");
-            return JsonSerializer.Serialize(new { error = "Failed to bulk mark emails", message = ex.Message });
+            throw new McpException("Failed to bulk mark emails.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/BulkMoveEmailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/BulkMoveEmailsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -26,32 +27,23 @@ public sealed class BulkMoveEmailsTool(
     {
         logger.LogInformation("Bulk moving emails to {Destination}", destination);
 
+        ToolGuard.RequireNonEmpty(destination, nameof(destination));
+
+        if (items == null || items.Length == 0)
+            throw new McpException("items array must not be empty");
+
+        if (items.Length > MaxBatchSize)
+            throw new McpException($"Batch size {items.Length} exceeds maximum of {MaxBatchSize}");
+
+        // Validate all items have required fields
+        foreach (var item in items)
+        {
+            if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
+                throw new McpException("Each item must have 'accountId' and 'emailId' fields");
+        }
+
         try
         {
-            if (string.IsNullOrEmpty(destination))
-            {
-                return JsonSerializer.Serialize(new { error = "destination is required" });
-            }
-
-            if (items == null || items.Length == 0)
-            {
-                return JsonSerializer.Serialize(new { error = "items array must not be empty" });
-            }
-
-            if (items.Length > MaxBatchSize)
-            {
-                return JsonSerializer.Serialize(new { error = $"Batch size {items.Length} exceeds maximum of {MaxBatchSize}" });
-            }
-
-            // Validate all items have required fields
-            foreach (var item in items)
-            {
-                if (string.IsNullOrEmpty(item.AccountId) || string.IsNullOrEmpty(item.EmailId))
-                {
-                    return JsonSerializer.Serialize(new { error = "Each item must have 'accountId' and 'emailId' fields" });
-                }
-            }
-
             // Resolve accounts once per unique accountId
             var accounts = await ResolveAccountsAsync(items);
 
@@ -71,7 +63,8 @@ public sealed class BulkMoveEmailsTool(
                 }
                 catch (Exception ex)
                 {
-                    return new BulkResultItem(item.EmailId, item.AccountId, false, ex.Message);
+                    logger.LogError(ex, "Error moving email {EmailId} in account {AccountId}", item.EmailId, item.AccountId);
+                    return new BulkResultItem(item.EmailId, item.AccountId, false, "Failed to move email.");
                 }
                 finally
                 {
@@ -96,10 +89,10 @@ public sealed class BulkMoveEmailsTool(
                     : new { r.EmailId, r.AccountId, r.Success, error = r.Error })
             }, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in bulk_move_emails tool");
-            return JsonSerializer.Serialize(new { error = "Failed to bulk move emails", message = ex.Message });
+            throw new McpException("Failed to bulk move emails.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/CreateContactTool.cs
+++ b/src/CalendarMcp.Core/Tools/CreateContactTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -30,30 +31,23 @@ public sealed class CreateContactTool(
         logger.LogInformation("Creating contact: displayName={DisplayName}, accountId={AccountId}",
             displayName, accountId);
 
+        // Determine which account to use
+        Models.AccountInfo account;
+        if (!string.IsNullOrEmpty(accountId))
+        {
+            account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+        }
+        else
+        {
+            var accounts = await accountRegistry.GetAllAccountsAsync();
+            var first = accounts.FirstOrDefault();
+            if (first == null)
+                throw new McpException("No enabled account available to create contact");
+            account = first;
+        }
+
         try
         {
-            // Determine which account to use
-            Models.AccountInfo? account = null;
-
-            if (!string.IsNullOrEmpty(accountId))
-            {
-                account = await accountRegistry.GetAccountAsync(accountId);
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new { error = $"Account '{accountId}' not found" });
-                }
-            }
-            else
-            {
-                var accounts = await accountRegistry.GetAllAccountsAsync();
-                account = accounts.FirstOrDefault();
-
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new { error = "No enabled account available to create contact" });
-                }
-            }
-
             // Parse email and phone into lists
             var emailAddresses = ParseCommaSeparated(email);
             var phoneNumbers = ParseCommaSeparated(phone);
@@ -78,14 +72,10 @@ public sealed class CreateContactTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in create_contact tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to create contact",
-                message = ex.Message
-            });
+            throw new McpException("Failed to create contact.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/CreateEventTool.cs
+++ b/src/CalendarMcp.Core/Tools/CreateEventTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -33,37 +34,23 @@ public sealed class CreateEventTool(
         logger.LogInformation("Creating event: subject={Subject}, start={Start}, end={End}, accountId={AccountId}",
             subject, start, end, accountId);
 
+        // Determine which account to use
+        Models.AccountInfo account;
+        if (!string.IsNullOrEmpty(accountId))
+        {
+            account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+        }
+        else
+        {
+            var accounts = await accountRegistry.GetAllAccountsAsync();
+            var first = accounts.FirstOrDefault();
+            if (first == null)
+                throw new McpException("No enabled account available to create event");
+            account = first;
+        }
+
         try
         {
-            // Determine which account to use
-            Models.AccountInfo? account = null;
-
-            if (!string.IsNullOrEmpty(accountId))
-            {
-                account = await accountRegistry.GetAccountAsync(accountId);
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = $"Account '{accountId}' not found"
-                    });
-                }
-            }
-            else
-            {
-                // Use first enabled account (could enhance with smarter routing)
-                var accounts = await accountRegistry.GetAllAccountsAsync();
-                account = accounts.FirstOrDefault();
-
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = "No enabled account available to create event"
-                    });
-                }
-            }
-
             // Create event
             var provider = providerFactory.GetProvider(account.Provider);
             var eventId = await provider.CreateEventAsync(
@@ -84,14 +71,10 @@ public sealed class CreateEventTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in create_event tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to create event",
-                message = ex.Message
-            });
+            throw new McpException("Failed to create event.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/DeleteContactTool.cs
+++ b/src/CalendarMcp.Core/Tools/DeleteContactTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -23,24 +24,12 @@ public sealed class DeleteContactTool(
         logger.LogInformation("Deleting contact: accountId={AccountId}, contactId={ContactId}",
             accountId, contactId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(contactId, nameof(contactId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new { error = "accountId is required" });
-            }
-
-            if (string.IsNullOrEmpty(contactId))
-            {
-                return JsonSerializer.Serialize(new { error = "contactId is required" });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new { error = $"Account '{accountId}' not found" });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.DeleteContactAsync(accountId, contactId, CancellationToken.None);
 
@@ -58,14 +47,10 @@ public sealed class DeleteContactTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in delete_contact tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to delete contact",
-                message = ex.Message
-            });
+            throw new McpException("Failed to delete contact.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/DeleteEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/DeleteEmailTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -23,33 +24,12 @@ public sealed class DeleteEmailTool(
         logger.LogInformation("Deleting email: accountId={AccountId}, emailId={EmailId}",
             accountId, emailId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "accountId is required"
-                });
-            }
-
-            if (string.IsNullOrEmpty(emailId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "emailId is required"
-                });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.DeleteEmailAsync(accountId, emailId, CancellationToken.None);
 
@@ -69,14 +49,10 @@ public sealed class DeleteEmailTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in delete_email tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to delete email",
-                message = ex.Message
-            });
+            throw new McpException("Failed to delete email.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/DeleteEventTool.cs
+++ b/src/CalendarMcp.Core/Tools/DeleteEventTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -24,37 +25,25 @@ public sealed class DeleteEventTool(
         logger.LogInformation("Deleting event: eventId={EventId}, accountId={AccountId}, calendarId={CalendarId}",
             eventId, accountId, calendarId);
 
+        ToolGuard.RequireNonEmpty(eventId, nameof(eventId));
+
+        // Determine which account to use
+        Models.AccountInfo account;
+        if (!string.IsNullOrEmpty(accountId))
+        {
+            account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+        }
+        else
+        {
+            var accounts = await accountRegistry.GetAllAccountsAsync();
+            var first = accounts.FirstOrDefault();
+            if (first == null)
+                throw new McpException("No enabled account available to delete event");
+            account = first;
+        }
+
         try
         {
-            // Determine which account to use
-            Models.AccountInfo? account = null;
-
-            if (!string.IsNullOrEmpty(accountId))
-            {
-                account = await accountRegistry.GetAccountAsync(accountId);
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = $"Account '{accountId}' not found"
-                    });
-                }
-            }
-            else
-            {
-                // Use first enabled account (could enhance with smarter routing)
-                var accounts = await accountRegistry.GetAllAccountsAsync();
-                account = accounts.FirstOrDefault();
-
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = "No enabled account available to delete event"
-                    });
-                }
-            }
-
             // Delete event
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.DeleteEventAsync(
@@ -76,14 +65,10 @@ public sealed class DeleteEventTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in delete_event tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to delete event",
-                message = ex.Message
-            });
+            throw new McpException("Failed to delete event.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetCalendarEventDetailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetCalendarEventDetailsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Utilities;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -27,56 +28,26 @@ public sealed class GetCalendarEventDetailsTool(
         logger.LogInformation("Getting calendar event details: accountId={AccountId}, calendarId={CalendarId}, eventId={EventId}, timeZone={TimeZone}",
             accountId, calendarId, eventId, timeZone);
 
+        var tz = TimeZoneHelper.TryGetTimeZone(timeZone);
+        if (tz == null)
+            throw new McpException($"Invalid IANA timezone: '{timeZone}'. Use a valid IANA timezone name such as 'America/Chicago', 'Europe/London', or 'Asia/Tokyo'.");
+
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(eventId, nameof(eventId));
+
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            var tz = TimeZoneHelper.TryGetTimeZone(timeZone);
-            if (tz == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Invalid IANA timezone: '{timeZone}'. Use a valid IANA timezone name such as 'America/Chicago', 'Europe/London', or 'Asia/Tokyo'."
-                });
-            }
-
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "accountId is required"
-                });
-            }
-
-            if (string.IsNullOrEmpty(eventId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "eventId is required"
-                });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             var evt = await provider.GetCalendarEventDetailsAsync(
-                accountId, 
-                calendarId ?? "primary", 
-                eventId, 
+                accountId,
+                calendarId ?? "primary",
+                eventId,
                 CancellationToken.None);
 
             if (evt == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Event '{eventId}' not found in account '{accountId}'"
-                });
-            }
+                throw new McpException($"Event '{eventId}' not found in account '{accountId}'");
 
             var response = new
             {
@@ -127,14 +98,10 @@ public sealed class GetCalendarEventDetailsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_calendar_event_details tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get calendar event details",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get calendar event details.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetCalendarEventsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetCalendarEventsTool.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Utilities;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -28,22 +29,12 @@ public sealed class GetCalendarEventsTool(
     {
         var tz = TimeZoneHelper.TryGetTimeZone(timeZone);
         if (tz == null)
-        {
-            return JsonSerializer.Serialize(new
-            {
-                error = $"Invalid IANA timezone: '{timeZone}'. Use a valid IANA timezone name such as 'America/Chicago', 'Europe/London', or 'Asia/Tokyo'."
-            });
-        }
+            throw new McpException($"Invalid IANA timezone: '{timeZone}'. Use a valid IANA timezone name such as 'America/Chicago', 'Europe/London', or 'Asia/Tokyo'.");
 
         if (string.IsNullOrEmpty(accountId))
         {
             if (string.IsNullOrEmpty(calendarId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "accountId is required"
-                });
-            }
+                throw new McpException("accountId is required");
 
             // calendarId provided but no accountId — try to resolve the account automatically
             try
@@ -68,32 +59,18 @@ public sealed class GetCalendarEventsTool(
                 var matchingAccountIds = lookupResults.OfType<string>().ToList();
 
                 if (matchingAccountIds.Count == 0)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = $"No calendar found with id '{calendarId}'. Provide accountId to specify which account to query."
-                    });
-                }
+                    throw new McpException($"No calendar found with id '{calendarId}'. Provide accountId to specify which account to query.");
 
                 if (matchingAccountIds.Count > 1)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = $"calendarId '{calendarId}' exists in multiple accounts; provide accountId to specify which account to query."
-                    });
-                }
+                    throw new McpException($"calendarId '{calendarId}' exists in multiple accounts; provide accountId to specify which account to query.");
 
                 accountId = matchingAccountIds[0];
                 logger.LogInformation("Resolved accountId={AccountId} from calendarId={CalendarId}", accountId, calendarId);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not McpException)
             {
                 logger.LogError(ex, "Error resolving accountId from calendarId {CalendarId}", calendarId);
-                return JsonSerializer.Serialize(new
-                {
-                    error = "Failed to resolve account from calendarId",
-                    message = ex.Message
-                });
+                throw new McpException("Failed to resolve account from calendarId.", ex);
             }
         }
 
@@ -105,16 +82,8 @@ public sealed class GetCalendarEventsTool(
 
         try
         {
-            var accounts = new[] { await accountRegistry.GetAccountAsync(accountId) }.Where(a => a != null).Cast<AccountInfo>();
-            var validAccounts = accounts.ToList();
-
-            if (validAccounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
+            var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+            var validAccounts = new List<AccountInfo> { account };
 
             // Query all accounts in parallel
             var warnings = new List<object>();
@@ -132,7 +101,7 @@ public sealed class GetCalendarEventsTool(
                     logger.LogError(ex, "Error getting calendar events from account {AccountId}", account!.Id);
                     lock (warnings)
                     {
-                        warnings.Add(new { accountId = account.Id, error = ex.Message });
+                        warnings.Add(new { accountId = account.Id, error = "Failed to retrieve events from this account." });
                     }
                     return Enumerable.Empty<CalendarEvent>();
                 }
@@ -172,14 +141,10 @@ public sealed class GetCalendarEventsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_calendar_events tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get calendar events",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get calendar events.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetContactDetailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetContactDetailsTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -23,34 +24,17 @@ public sealed class GetContactDetailsTool(
         logger.LogInformation("Getting contact details: accountId={AccountId}, contactId={ContactId}",
             accountId, contactId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(contactId, nameof(contactId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new { error = "accountId is required" });
-            }
-
-            if (string.IsNullOrEmpty(contactId))
-            {
-                return JsonSerializer.Serialize(new { error = "contactId is required" });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new { error = $"Account '{accountId}' not found" });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             var contact = await provider.GetContactDetailsAsync(accountId, contactId, CancellationToken.None);
 
             if (contact == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Contact '{contactId}' not found in account '{accountId}'"
-                });
-            }
+                throw new McpException($"Contact '{contactId}' not found in account '{accountId}'");
 
             var response = new
             {
@@ -84,14 +68,10 @@ public sealed class GetContactDetailsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_contact_details tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get contact details",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get contact details.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetContactsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetContactsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -23,21 +24,20 @@ public sealed class GetContactsTool(
     {
         logger.LogInformation("Getting contacts: accountId={AccountId}, count={Count}", accountId, count);
 
+        List<AccountInfo> validAccounts;
+        if (string.IsNullOrEmpty(accountId))
+        {
+            validAccounts = (await accountRegistry.GetAllAccountsAsync()).ToList();
+            if (validAccounts.Count == 0)
+                throw new McpException("No accounts found");
+        }
+        else
+        {
+            validAccounts = new List<AccountInfo> { await ToolGuard.RequireAccountAsync(accountRegistry, accountId) };
+        }
+
         try
         {
-            var accounts = string.IsNullOrEmpty(accountId)
-                ? await accountRegistry.GetAllAccountsAsync()
-                : new[] { await accountRegistry.GetAccountAsync(accountId) }.Where(a => a != null).Cast<AccountInfo>();
-
-            var validAccounts = accounts.ToList();
-
-            if (validAccounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = accountId != null ? $"Account '{accountId}' not found" : "No accounts found"
-                });
-            }
 
             var tasks = validAccounts.Select(async account =>
             {
@@ -81,14 +81,10 @@ public sealed class GetContactsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_contacts tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get contacts",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get contacts.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetContextualEmailSummaryTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetContextualEmailSummaryTool.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -46,15 +47,13 @@ public sealed partial class GetContextualEmailSummaryTool(
             "Getting contextual email summary: topics={Topics}, countPerAccount={Count}, unreadOnly={UnreadOnly}",
             topics, countPerAccount, unreadOnly);
 
+        // Get all enabled accounts
+        var accounts = (await accountRegistry.GetAllAccountsAsync()).ToList();
+        if (accounts.Count == 0)
+            throw new McpException("No accounts configured");
+
         try
         {
-            // Get all enabled accounts
-            var accounts = (await accountRegistry.GetAllAccountsAsync()).ToList();
-            
-            if (accounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new { error = "No accounts configured" }, JsonOptions);
-            }
 
             // Parse topic keywords
             var searchKeywords = ParseTopics(topics);
@@ -86,14 +85,10 @@ public sealed partial class GetContextualEmailSummaryTool(
 
             return JsonSerializer.Serialize(summary, JsonOptions);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_contextual_email_summary tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get contextual email summary",
-                message = ex.Message
-            }, JsonOptions);
+            throw new McpException("Failed to get contextual email summary.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/GetEmailAttachmentTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailAttachmentTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -32,37 +33,30 @@ public sealed class GetEmailAttachmentTool(
         [Description("Required. Provider-side attachment ID, from the attachments[] array on get_email_details (e.g. 'part-0' for Gmail/IMAP, an opaque string for Microsoft Graph).")] string attachmentId,
         [Description("'stash' (default) returns an attachmentId for use in send_email. 'inline' returns base64Content directly; capped at 1 MB.")] string mode = "stash")
     {
-        if (string.IsNullOrEmpty(accountId)) return Err("accountId is required");
-        if (string.IsNullOrEmpty(emailId)) return Err("emailId is required");
-        if (string.IsNullOrEmpty(attachmentId)) return Err("attachmentId is required");
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        ToolGuard.RequireNonEmpty(attachmentId, nameof(attachmentId));
 
         var normalizedMode = mode?.Trim().ToLowerInvariant() ?? "stash";
         if (normalizedMode is not ("stash" or "inline"))
-        {
-            return Err($"mode '{mode}' is invalid; use 'stash' or 'inline'.");
-        }
+            throw new McpException($"mode '{mode}' is invalid; use 'stash' or 'inline'.");
+
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
 
         try
         {
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null) return Err($"Account '{accountId}' not found");
-
             var provider = providerFactory.GetProvider(account.Provider);
             var content = await provider.GetEmailAttachmentContentAsync(
                 accountId, emailId, attachmentId, CancellationToken.None);
 
             if (content == null)
-            {
-                return Err($"Attachment '{attachmentId}' on email '{emailId}' was not found or could not be fetched.");
-            }
+                throw new McpException($"Attachment '{attachmentId}' on email '{emailId}' was not found or could not be fetched.");
 
             if (normalizedMode == "inline")
             {
                 if (content.Bytes.LongLength > InlineSizeLimitBytes)
-                {
-                    return Err(
+                    throw new McpException(
                         $"Attachment is {content.Bytes.LongLength:N0} bytes; inline mode is capped at {InlineSizeLimitBytes:N0} bytes. Re-call with mode='stash' and pass the returned attachmentId to send_email, or extract the bytes by other means.");
-                }
                 return JsonSerializer.Serialize(new
                 {
                     name = content.Name,
@@ -75,10 +69,8 @@ public sealed class GetEmailAttachmentTool(
             // stash mode
             var stored = attachmentStore.Put(content.Name, content.ContentType, content.Bytes);
             if (stored == null)
-            {
-                return Err(
+                throw new McpException(
                     $"Could not stash the attachment ({content.Bytes.LongLength:N0} bytes); the attachment is over the per-attachment cap or the store is full. Try inline mode if the file is small.");
-            }
 
             logger.LogInformation(
                 "Stashed inbound attachment {AttachmentId} from {EmailId} as {StoreId} ({Size} bytes)",
@@ -93,15 +85,10 @@ public sealed class GetEmailAttachmentTool(
                 expiresAt = stored.ExpiresAt,
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_email_attachment tool");
-            return Err("Failed to fetch attachment", ex.Message);
+            throw new McpException("Failed to fetch attachment.", ex);
         }
     }
-
-    private static string Err(string error, string? detail = null)
-        => detail == null
-            ? JsonSerializer.Serialize(new { error })
-            : JsonSerializer.Serialize(new { error, detail });
 }

--- a/src/CalendarMcp.Core/Tools/GetEmailDetailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailDetailsTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -23,43 +24,17 @@ public sealed class GetEmailDetailsTool(
         logger.LogInformation("Getting email details: accountId={AccountId}, emailId={EmailId}",
             accountId, emailId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "accountId is required"
-                });
-            }
-
-            if (string.IsNullOrEmpty(emailId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "emailId is required"
-                });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             var email = await provider.GetEmailDetailsAsync(accountId, emailId, CancellationToken.None);
 
             if (email == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Email '{emailId}' not found in account '{accountId}'"
-                });
-            }
+                throw new McpException($"Email '{emailId}' not found in account '{accountId}'");
 
             var response = new
             {
@@ -92,14 +67,10 @@ public sealed class GetEmailDetailsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_email_details tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get email details",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get email details.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetEmailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetEmailsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -25,22 +26,21 @@ public sealed class GetEmailsTool(
         logger.LogInformation("Getting emails: accountId={AccountId}, count={Count}, unreadOnly={UnreadOnly}",
             accountId, count, unreadOnly);
 
+        // Determine which accounts to query
+        List<AccountInfo> validAccounts;
+        if (string.IsNullOrEmpty(accountId))
+        {
+            validAccounts = (await accountRegistry.GetAllAccountsAsync()).ToList();
+            if (validAccounts.Count == 0)
+                throw new McpException("No accounts found");
+        }
+        else
+        {
+            validAccounts = new List<AccountInfo> { await ToolGuard.RequireAccountAsync(accountRegistry, accountId) };
+        }
+
         try
         {
-            // Determine which accounts to query
-            var accounts = string.IsNullOrEmpty(accountId)
-                ? await accountRegistry.GetAllAccountsAsync()
-                : new[] { await accountRegistry.GetAccountAsync(accountId) }.Where(a => a != null).Cast<AccountInfo>();
-
-            var validAccounts = accounts.ToList();
-
-            if (validAccounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = accountId != null ? $"Account '{accountId}' not found" : "No accounts found"
-                });
-            }
 
             // Query all accounts in parallel
             var tasks = validAccounts.Select(async account =>
@@ -85,14 +85,10 @@ public sealed class GetEmailsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_emails tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get emails",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get emails.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/GetUnsubscribeInfoTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetUnsubscribeInfoTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -23,23 +24,17 @@ public sealed class GetUnsubscribeInfoTool(
         logger.LogInformation("Getting unsubscribe info: accountId={AccountId}, emailId={EmailId}",
             accountId, emailId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-                return JsonSerializer.Serialize(new { error = "accountId is required" });
-
-            if (string.IsNullOrEmpty(emailId))
-                return JsonSerializer.Serialize(new { error = "emailId is required" });
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-                return JsonSerializer.Serialize(new { error = $"Account '{accountId}' not found" });
-
             var provider = providerFactory.GetProvider(account.Provider);
             var email = await provider.GetEmailDetailsAsync(accountId, emailId, CancellationToken.None);
 
             if (email == null)
-                return JsonSerializer.Serialize(new { error = $"Email '{emailId}' not found in account '{accountId}'" });
+                throw new McpException($"Email '{emailId}' not found in account '{accountId}'");
 
             if (email.UnsubscribeInfo == null)
             {
@@ -66,14 +61,10 @@ public sealed class GetUnsubscribeInfoTool(
 
             return JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in get_unsubscribe_info tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to get unsubscribe info",
-                message = ex.Message
-            });
+            throw new McpException("Failed to get unsubscribe info.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/ListAccountsTool.cs
+++ b/src/CalendarMcp.Core/Tools/ListAccountsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -41,14 +42,10 @@ public sealed class ListAccountsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error listing accounts");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to list accounts",
-                message = ex.Message
-            });
+            throw new McpException("Failed to list accounts.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/ListCalendarsTool.cs
+++ b/src/CalendarMcp.Core/Tools/ListCalendarsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -22,22 +23,21 @@ public sealed class ListCalendarsTool(
     {
         logger.LogInformation("Listing calendars: accountId={AccountId}", accountId);
 
+        // Determine which accounts to query
+        List<AccountInfo> validAccounts;
+        if (string.IsNullOrEmpty(accountId))
+        {
+            validAccounts = accountRegistry.GetEnabledAccounts().ToList();
+            if (validAccounts.Count == 0)
+                throw new McpException("No accounts found");
+        }
+        else
+        {
+            validAccounts = new List<AccountInfo> { await ToolGuard.RequireAccountAsync(accountRegistry, accountId) };
+        }
+
         try
         {
-            // Determine which accounts to query
-            var accounts = string.IsNullOrEmpty(accountId)
-                ? accountRegistry.GetEnabledAccounts()
-                : new[] { await accountRegistry.GetAccountAsync(accountId) }.Where(a => a != null).Cast<AccountInfo>();
-
-            var validAccounts = accounts.ToList();
-
-            if (validAccounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = accountId != null ? $"Account '{accountId}' not found" : "No accounts found"
-                });
-            }
 
             // Query all accounts in parallel
             var tasks = validAccounts.Select(async account =>
@@ -79,14 +79,10 @@ public sealed class ListCalendarsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in list_calendars tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to list calendars",
-                message = ex.Message
-            });
+            throw new McpException("Failed to list calendars.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/MarkEmailAsReadTool.cs
+++ b/src/CalendarMcp.Core/Tools/MarkEmailAsReadTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -24,33 +25,12 @@ public sealed class MarkEmailAsReadTool(
         logger.LogInformation("Marking email as read: accountId={AccountId}, emailId={EmailId}, isRead={IsRead}",
             accountId, emailId, isRead);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "accountId is required"
-                });
-            }
-
-            if (string.IsNullOrEmpty(emailId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "emailId is required"
-                });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.MarkEmailAsReadAsync(accountId, emailId, isRead, CancellationToken.None);
 
@@ -71,14 +51,10 @@ public sealed class MarkEmailAsReadTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in mark_email_as_read tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to mark email as read",
-                message = ex.Message
-            });
+            throw new McpException("Failed to mark email as read.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/MoveEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/MoveEmailTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -24,41 +25,13 @@ public sealed class MoveEmailTool(
         logger.LogInformation("Moving email: accountId={AccountId}, emailId={EmailId}, destination={Destination}",
             accountId, emailId, destination);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        ToolGuard.RequireNonEmpty(destination, nameof(destination));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "accountId is required"
-                });
-            }
-
-            if (string.IsNullOrEmpty(emailId))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "emailId is required"
-                });
-            }
-
-            if (string.IsNullOrEmpty(destination))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "destination is required"
-                });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.MoveEmailAsync(accountId, emailId, destination, CancellationToken.None);
 
@@ -79,14 +52,10 @@ public sealed class MoveEmailTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in move_email tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to move email",
-                message = ex.Message
-            });
+            throw new McpException("Failed to move email.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/RespondToEventTool.cs
+++ b/src/CalendarMcp.Core/Tools/RespondToEventTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -26,49 +27,35 @@ public sealed class RespondToEventTool(
         logger.LogInformation("Responding to event: eventId={EventId}, response={Response}, accountId={AccountId}, calendarId={CalendarId}",
             eventId, response, accountId, calendarId);
 
+        ToolGuard.RequireNonEmpty(eventId, nameof(eventId));
+        ToolGuard.RequireNonEmpty(response, nameof(response));
+
+        // Validate response type
+        var normalizedResponse = response.ToLowerInvariant();
+        if (normalizedResponse != "accept" && normalizedResponse != "accepted" &&
+            normalizedResponse != "tentative" && normalizedResponse != "tentativelyaccepted" &&
+            normalizedResponse != "decline" && normalizedResponse != "declined")
+        {
+            throw new McpException("Invalid response type. Valid values are: accept, tentative, decline");
+        }
+
+        // Determine which account to use
+        Models.AccountInfo account;
+        if (!string.IsNullOrEmpty(accountId))
+        {
+            account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+        }
+        else
+        {
+            var accounts = await accountRegistry.GetAllAccountsAsync();
+            var first = accounts.FirstOrDefault();
+            if (first == null)
+                throw new McpException("No enabled account available to respond to event");
+            account = first;
+        }
+
         try
         {
-            // Validate response type
-            var normalizedResponse = response.ToLowerInvariant();
-            if (normalizedResponse != "accept" && normalizedResponse != "accepted" &&
-                normalizedResponse != "tentative" && normalizedResponse != "tentativelyaccepted" &&
-                normalizedResponse != "decline" && normalizedResponse != "declined")
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "Invalid response type. Valid values are: accept, tentative, decline"
-                });
-            }
-
-            // Determine which account to use
-            Models.AccountInfo? account = null;
-
-            if (!string.IsNullOrEmpty(accountId))
-            {
-                account = await accountRegistry.GetAccountAsync(accountId);
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = $"Account '{accountId}' not found"
-                    });
-                }
-            }
-            else
-            {
-                // Use first enabled account (could enhance with smarter routing)
-                var accounts = await accountRegistry.GetAllAccountsAsync();
-                account = accounts.FirstOrDefault();
-
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = "No enabled account available to respond to event"
-                    });
-                }
-            }
-
             // Respond to event
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.RespondToEventAsync(
@@ -92,14 +79,10 @@ public sealed class RespondToEventTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in respond_to_event tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to respond to event",
-                message = ex.Message
-            });
+            throw new McpException("Failed to respond to event.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/SearchContactsTool.cs
+++ b/src/CalendarMcp.Core/Tools/SearchContactsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -25,29 +26,23 @@ public sealed class SearchContactsTool(
         logger.LogInformation("Searching contacts: query={Query}, accountId={AccountId}, count={Count}",
             query, accountId, count);
 
+        if (string.IsNullOrWhiteSpace(query))
+            throw new McpException("query is required");
+
+        List<AccountInfo> validAccounts;
+        if (string.IsNullOrEmpty(accountId))
+        {
+            validAccounts = (await accountRegistry.GetAllAccountsAsync()).ToList();
+            if (validAccounts.Count == 0)
+                throw new McpException("No accounts found");
+        }
+        else
+        {
+            validAccounts = new List<AccountInfo> { await ToolGuard.RequireAccountAsync(accountRegistry, accountId) };
+        }
+
         try
         {
-            if (string.IsNullOrWhiteSpace(query))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "Parameter 'query' is required"
-                });
-            }
-
-            var accounts = string.IsNullOrEmpty(accountId)
-                ? await accountRegistry.GetAllAccountsAsync()
-                : new[] { await accountRegistry.GetAccountAsync(accountId) }.Where(a => a != null).Cast<AccountInfo>();
-
-            var validAccounts = accounts.ToList();
-
-            if (validAccounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = accountId != null ? $"Account '{accountId}' not found" : "No accounts found"
-                });
-            }
 
             var tasks = validAccounts.Select(async account =>
             {
@@ -91,14 +86,10 @@ public sealed class SearchContactsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in search_contacts tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to search contacts",
-                message = ex.Message
-            });
+            throw new McpException("Failed to search contacts.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/SearchEmailsTool.cs
+++ b/src/CalendarMcp.Core/Tools/SearchEmailsTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -27,30 +28,24 @@ public sealed class SearchEmailsTool(
         logger.LogInformation("Searching emails: query={Query}, accountId={AccountId}, count={Count}",
             query, accountId, count);
 
+        if (string.IsNullOrWhiteSpace(query))
+            throw new McpException("query is required");
+
+        // Determine which accounts to query
+        List<AccountInfo> validAccounts;
+        if (string.IsNullOrEmpty(accountId))
+        {
+            validAccounts = (await accountRegistry.GetAllAccountsAsync()).ToList();
+            if (validAccounts.Count == 0)
+                throw new McpException("No accounts found");
+        }
+        else
+        {
+            validAccounts = new List<AccountInfo> { await ToolGuard.RequireAccountAsync(accountRegistry, accountId) };
+        }
+
         try
         {
-            if (string.IsNullOrWhiteSpace(query))
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = "Parameter 'query' is required"
-                });
-            }
-
-            // Determine which accounts to query
-            var accounts = string.IsNullOrEmpty(accountId)
-                ? await accountRegistry.GetAllAccountsAsync()
-                : new[] { await accountRegistry.GetAccountAsync(accountId) }.Where(a => a != null).Cast<AccountInfo>();
-
-            var validAccounts = accounts.ToList();
-
-            if (validAccounts.Count == 0)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = accountId != null ? $"Account '{accountId}' not found" : "No accounts found"
-                });
-            }
 
             // Query all accounts in parallel
             var tasks = validAccounts.Select(async account =>
@@ -96,14 +91,10 @@ public sealed class SearchEmailsTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in search_emails tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to search emails",
-                message = ex.Message
-            });
+            throw new McpException("Failed to search emails.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Core/Tools/SendEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/SendEmailTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Models;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -35,30 +36,21 @@ public sealed class SendEmailTool(
         body = StripCdataWrapper(body);
 
         if (to is null || to.Count == 0)
-        {
-            return JsonSerializer.Serialize(new
-            {
-                error = "At least one recipient address is required in the 'to' field."
-            });
-        }
+            throw new McpException("At least one recipient address is required in the 'to' field.");
 
         List<OutboundEmailAttachment>? resolvedAttachments = null;
         if (attachments is { Count: > 0 })
         {
             var shapeError = ValidateAttachmentShapes(attachments);
             if (shapeError != null)
-            {
-                return JsonSerializer.Serialize(new { error = shapeError });
-            }
+                throw new McpException(shapeError);
 
             // Second pass: consume any AttachmentId-backed entries. From this
             // point on, IDs are removed from the store; an error after this
             // requires the agent to re-upload.
             var (resolved, consumeError) = ResolveAttachments(attachments);
             if (consumeError != null)
-            {
-                return JsonSerializer.Serialize(new { error = consumeError });
-            }
+                throw new McpException(consumeError);
             resolvedAttachments = resolved;
         }
 
@@ -67,62 +59,53 @@ public sealed class SendEmailTool(
         logger.LogInformation("Sending email: to={To}, subject={Subject}, accountId={AccountId}",
             toJoined, subject, accountId);
 
+        // Determine which account to use
+        Models.AccountInfo account;
+        if (!string.IsNullOrEmpty(accountId))
+        {
+            // Explicit account specified
+            account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+        }
+        else
+        {
+            Models.AccountInfo? selected = null;
+
+            // Smart routing: extract domain from the first recipient
+            var recipientDomain = to[0].Split('@').LastOrDefault();
+            if (!string.IsNullOrEmpty(recipientDomain))
+            {
+                var matchingAccounts = accountRegistry.GetAccountsByDomain(recipientDomain).ToList();
+
+                if (matchingAccounts.Count == 1)
+                {
+                    selected = matchingAccounts[0];
+                    logger.LogInformation("Smart routing selected account {AccountId} based on domain {Domain}",
+                        selected.Id, recipientDomain);
+                }
+                else if (matchingAccounts.Count > 1)
+                {
+                    // Multiple matches, use first one (could enhance with priority logic)
+                    selected = matchingAccounts.First();
+                    logger.LogInformation("Smart routing selected account {AccountId} from {Count} matches",
+                        selected.Id, matchingAccounts.Count);
+                }
+            }
+
+            // If still no account, use default (first enabled)
+            if (selected == null)
+            {
+                var allAccounts = await accountRegistry.GetAllAccountsAsync();
+                selected = allAccounts.FirstOrDefault();
+            }
+
+            if (selected == null)
+                throw new McpException("No enabled account available to send email");
+
+            account = selected;
+        }
+
         try
         {
-            // Determine which account to use
-            Models.AccountInfo? account = null;
-
-            if (!string.IsNullOrEmpty(accountId))
-            {
-                // Explicit account specified
-                account = await accountRegistry.GetAccountAsync(accountId);
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = $"Account '{accountId}' not found"
-                    });
-                }
-            }
-            else
-            {
-                // Smart routing: extract domain from the first recipient
-                var recipientDomain = to[0].Split('@').LastOrDefault();
-                if (!string.IsNullOrEmpty(recipientDomain))
-                {
-                    var matchingAccounts = accountRegistry.GetAccountsByDomain(recipientDomain).ToList();
-
-                    if (matchingAccounts.Count == 1)
-                    {
-                        account = matchingAccounts[0];
-                        logger.LogInformation("Smart routing selected account {AccountId} based on domain {Domain}",
-                            account.Id, recipientDomain);
-                    }
-                    else if (matchingAccounts.Count > 1)
-                    {
-                        // Multiple matches, use first one (could enhance with priority logic)
-                        account = matchingAccounts.First();
-                        logger.LogInformation("Smart routing selected account {AccountId} from {Count} matches",
-                            account.Id, matchingAccounts.Count);
-                    }
-                }
-
-                // If still no account, use default (first enabled)
-                if (account == null)
-                {
-                    var allAccounts = await accountRegistry.GetAllAccountsAsync();
-                    account = allAccounts.FirstOrDefault();
-                }
-
-                if (account == null)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        error = "No enabled account available to send email"
-                    });
-                }
-            }
-
             // Send email
             var provider = providerFactory.GetProvider(account.Provider);
             var messageId = await provider.SendEmailAsync(
@@ -142,16 +125,10 @@ public sealed class SendEmailTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in send_email tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to send email",
-                errorType = ex.GetType().Name,
-                message = ex.Message,
-                inner = ex.InnerException?.Message
-            });
+            throw new McpException("Failed to send email.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/ToolGuard.cs
+++ b/src/CalendarMcp.Core/Tools/ToolGuard.cs
@@ -1,0 +1,27 @@
+using CalendarMcp.Core.Models;
+using CalendarMcp.Core.Services;
+using ModelContextProtocol;
+
+namespace CalendarMcp.Core.Tools;
+
+/// <summary>
+/// Validation helpers that throw <see cref="McpException"/> so input errors surface
+/// as MCP protocol errors (isError=true) rather than success payloads with an embedded
+/// error field.
+/// </summary>
+internal static class ToolGuard
+{
+    public static void RequireNonEmpty(string? value, string paramName)
+    {
+        if (string.IsNullOrEmpty(value))
+            throw new McpException($"{paramName} is required");
+    }
+
+    public static async Task<AccountInfo> RequireAccountAsync(IAccountRegistry registry, string accountId)
+    {
+        var account = await registry.GetAccountAsync(accountId);
+        if (account == null)
+            throw new McpException($"Account '{accountId}' not found");
+        return account;
+    }
+}

--- a/src/CalendarMcp.Core/Tools/UnsubscribeFromEmailTool.cs
+++ b/src/CalendarMcp.Core/Tools/UnsubscribeFromEmailTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Utilities;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -26,23 +27,17 @@ public sealed class UnsubscribeFromEmailTool(
         logger.LogInformation("Unsubscribe request: accountId={AccountId}, emailId={EmailId}, method={Method}",
             accountId, emailId, method);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(emailId, nameof(emailId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-                return JsonSerializer.Serialize(new { error = "accountId is required" });
-
-            if (string.IsNullOrEmpty(emailId))
-                return JsonSerializer.Serialize(new { error = "emailId is required" });
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-                return JsonSerializer.Serialize(new { error = $"Account '{accountId}' not found" });
-
             var provider = providerFactory.GetProvider(account.Provider);
             var email = await provider.GetEmailDetailsAsync(accountId, emailId, CancellationToken.None);
 
             if (email == null)
-                return JsonSerializer.Serialize(new { error = $"Email '{emailId}' not found in account '{accountId}'" });
+                throw new McpException($"Email '{emailId}' not found in account '{accountId}'");
 
             if (email.UnsubscribeInfo == null)
             {
@@ -79,14 +74,10 @@ public sealed class UnsubscribeFromEmailTool(
                 result.ErrorDetails
             }, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in unsubscribe_from_email tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to unsubscribe",
-                message = ex.Message
-            });
+            throw new McpException("Failed to unsubscribe.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/UpdateContactTool.cs
+++ b/src/CalendarMcp.Core/Tools/UpdateContactTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -31,24 +32,12 @@ public sealed class UpdateContactTool(
         logger.LogInformation("Updating contact: accountId={AccountId}, contactId={ContactId}",
             accountId, contactId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(contactId, nameof(contactId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            if (string.IsNullOrEmpty(accountId))
-            {
-                return JsonSerializer.Serialize(new { error = "accountId is required" });
-            }
-
-            if (string.IsNullOrEmpty(contactId))
-            {
-                return JsonSerializer.Serialize(new { error = "contactId is required" });
-            }
-
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new { error = $"Account '{accountId}' not found" });
-            }
-
             var emailAddresses = ParseCommaSeparated(email);
             var phoneNumbers = ParseCommaSeparated(phone);
 
@@ -74,14 +63,10 @@ public sealed class UpdateContactTool(
                 WriteIndented = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in update_contact tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to update contact",
-                message = ex.Message
-            });
+            throw new McpException("Failed to update contact.", ex);
         }
     }
 

--- a/src/CalendarMcp.Core/Tools/UpdateEventTool.cs
+++ b/src/CalendarMcp.Core/Tools/UpdateEventTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using CalendarMcp.Core.Services;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace CalendarMcp.Core.Tools;
@@ -30,17 +31,13 @@ public sealed class UpdateEventTool(
         logger.LogInformation("Updating event: eventId={EventId}, accountId={AccountId}, calendarId={CalendarId}",
             eventId, accountId, calendarId);
 
+        ToolGuard.RequireNonEmpty(accountId, nameof(accountId));
+        ToolGuard.RequireNonEmpty(calendarId, nameof(calendarId));
+        ToolGuard.RequireNonEmpty(eventId, nameof(eventId));
+        var account = await ToolGuard.RequireAccountAsync(accountRegistry, accountId);
+
         try
         {
-            var account = await accountRegistry.GetAccountAsync(accountId);
-            if (account == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    error = $"Account '{accountId}' not found"
-                });
-            }
-
             var provider = providerFactory.GetProvider(account.Provider);
             await provider.UpdateEventAsync(
                 accountId, calendarId, eventId, subject, start, end, location, attendees, timeZone, CancellationToken.None);
@@ -53,14 +50,10 @@ public sealed class UpdateEventTool(
                 calendarUsed = calendarId
             }, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not McpException)
         {
             logger.LogError(ex, "Error in update_event tool");
-            return JsonSerializer.Serialize(new
-            {
-                error = "Failed to update event",
-                message = ex.Message
-            });
+            throw new McpException("Failed to update event.", ex);
         }
     }
 }

--- a/src/CalendarMcp.Tests/Tools/BulkDeleteEmailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/BulkDeleteEmailsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,21 +13,20 @@ namespace CalendarMcp.Tests.Tools;
 public class BulkDeleteEmailsToolTests
 {
     [TestMethod]
-    public async Task BulkDeleteEmails_EmptyArray_ReturnsError()
+    public async Task BulkDeleteEmails_EmptyArray_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new BulkDeleteEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkDeleteEmailsTool>.Instance);
 
-        var result = await tool.BulkDeleteEmails([]);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("items array must not be empty", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.BulkDeleteEmails([]));
+        Assert.AreEqual("items array must not be empty", ex.Message);
     }
 
     [TestMethod]
-    public async Task BulkDeleteEmails_ExceedsMaxBatch_ReturnsError()
+    public async Task BulkDeleteEmails_ExceedsMaxBatch_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
@@ -37,10 +37,9 @@ public class BulkDeleteEmailsToolTests
             .Select(i => new BulkEmailItem { AccountId = "acc-1", EmailId = $"email-{i}" })
             .ToArray();
 
-        var result = await tool.BulkDeleteEmails(emails);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("exceeds maximum"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.BulkDeleteEmails(emails));
+        Assert.IsTrue(ex.Message.Contains("exceeds maximum"));
     }
 
     [TestMethod]

--- a/src/CalendarMcp.Tests/Tools/BulkMarkEmailsAsReadToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/BulkMarkEmailsAsReadToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,17 +13,16 @@ namespace CalendarMcp.Tests.Tools;
 public class BulkMarkEmailsAsReadToolTests
 {
     [TestMethod]
-    public async Task BulkMarkEmailsAsRead_EmptyArray_ReturnsError()
+    public async Task BulkMarkEmailsAsRead_EmptyArray_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new BulkMarkEmailsAsReadTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMarkEmailsAsReadTool>.Instance);
 
-        var result = await tool.BulkMarkEmailsAsRead([], true);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("items array must not be empty", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.BulkMarkEmailsAsRead([], true));
+        Assert.AreEqual("items array must not be empty", ex.Message);
     }
 
     [TestMethod]

--- a/src/CalendarMcp.Tests/Tools/BulkMoveEmailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/BulkMoveEmailsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,31 +13,29 @@ namespace CalendarMcp.Tests.Tools;
 public class BulkMoveEmailsToolTests
 {
     [TestMethod]
-    public async Task BulkMoveEmails_EmptyDestination_ReturnsError()
+    public async Task BulkMoveEmails_EmptyDestination_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new BulkMoveEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMoveEmailsTool>.Instance);
 
-        var result = await tool.BulkMoveEmails([new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" }], "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("destination is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.BulkMoveEmails([new BulkEmailItem { AccountId = "acc-1", EmailId = "e1" }], ""));
+        Assert.AreEqual("destination is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task BulkMoveEmails_EmptyArray_ReturnsError()
+    public async Task BulkMoveEmails_EmptyArray_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new BulkMoveEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<BulkMoveEmailsTool>.Instance);
 
-        var result = await tool.BulkMoveEmails([], "archive");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("items array must not be empty", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.BulkMoveEmails([], "archive"));
+        Assert.AreEqual("items array must not be empty", ex.Message);
     }
 
     [TestMethod]

--- a/src/CalendarMcp.Tests/Tools/CreateEventToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/CreateEventToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -47,7 +48,7 @@ public class CreateEventToolTests
     }
 
     [TestMethod]
-    public async Task CreateEvent_AccountNotFound_ReturnsError()
+    public async Task CreateEvent_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -57,10 +58,9 @@ public class CreateEventToolTests
         var tool = new CreateEventTool(regExp.Instance(), factExp.Instance(),
             NullLogger<CreateEventTool>.Instance);
 
-        var result = await tool.CreateEvent("Meeting", Start, End, "nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.CreateEvent("Meeting", Start, End, "nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
@@ -97,7 +97,7 @@ public class CreateEventToolTests
     }
 
     [TestMethod]
-    public async Task CreateEvent_NoAccounts_ReturnsError()
+    public async Task CreateEvent_NoAccounts_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAllAccountsAsync()
@@ -107,10 +107,9 @@ public class CreateEventToolTests
         var tool = new CreateEventTool(regExp.Instance(), factExp.Instance(),
             NullLogger<CreateEventTool>.Instance);
 
-        var result = await tool.CreateEvent("Meeting", Start, End);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("No enabled account"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.CreateEvent("Meeting", Start, End));
+        Assert.IsTrue(ex.Message.Contains("No enabled account"));
         regExp.Verify();
     }
 }

--- a/src/CalendarMcp.Tests/Tools/DeleteEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/DeleteEmailToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -26,29 +27,27 @@ public class DeleteEmailToolTests
     }
 
     [TestMethod]
-    public async Task DeleteEmail_EmptyAccountId_ReturnsError()
+    public async Task DeleteEmail_EmptyAccountId_ThrowsMcpException()
     {
         var (tool, _, _, _) = CreateTool();
 
-        var result = await tool.DeleteEmail("", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.DeleteEmail("", "email-1"));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task DeleteEmail_EmptyEmailId_ReturnsError()
+    public async Task DeleteEmail_EmptyEmailId_ThrowsMcpException()
     {
         var (tool, _, _, _) = CreateTool();
 
-        var result = await tool.DeleteEmail("acc-1", "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("emailId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.DeleteEmail("acc-1", ""));
+        Assert.AreEqual("emailId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task DeleteEmail_AccountNotFound_ReturnsError()
+    public async Task DeleteEmail_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -60,10 +59,9 @@ public class DeleteEmailToolTests
             factExp.Instance(),
             NullLogger<DeleteEmailTool>.Instance);
 
-        var result = await tool.DeleteEmail("nonexistent", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.DeleteEmail("nonexistent", "email-1"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
@@ -102,7 +100,7 @@ public class DeleteEmailToolTests
     }
 
     [TestMethod]
-    public async Task DeleteEmail_ProviderThrows_ReturnsErrorJson()
+    public async Task DeleteEmail_ProviderThrows_ThrowsGenericMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
 
@@ -112,7 +110,7 @@ public class DeleteEmailToolTests
 
         var provExp = new IProviderServiceCreateExpectations();
         provExp.Setups.DeleteEmailAsync("acc-1", "email-1", Arg.Any<CancellationToken>())
-            .Callback((_, _, _) => throw new InvalidOperationException("Provider error"));
+            .Callback((_, _, _) => throw new InvalidOperationException("Sensitive provider detail"));
 
         var factExp = new IProviderServiceFactoryCreateExpectations();
         factExp.Setups.GetProvider("microsoft365")
@@ -123,10 +121,14 @@ public class DeleteEmailToolTests
             factExp.Instance(),
             NullLogger<DeleteEmailTool>.Instance);
 
-        var result = await tool.DeleteEmail("acc-1", "email-1");
-        var doc = JsonDocument.Parse(result);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.DeleteEmail("acc-1", "email-1"));
 
-        Assert.AreEqual("Failed to delete email", doc.RootElement.GetProperty("error").GetString());
+        // Generic action-level message — provider's exception message must NOT leak.
+        Assert.AreEqual("Failed to delete email.", ex.Message);
+        Assert.IsFalse(ex.Message.Contains("Sensitive provider detail"),
+            "Provider exception message should not propagate to McpException.Message.");
+        Assert.IsInstanceOfType<InvalidOperationException>(ex.InnerException);
 
         regExp.Verify();
         factExp.Verify();

--- a/src/CalendarMcp.Tests/Tools/DeleteEventToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/DeleteEventToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -41,7 +42,7 @@ public class DeleteEventToolTests
     }
 
     [TestMethod]
-    public async Task DeleteEvent_AccountNotFound_ReturnsError()
+    public async Task DeleteEvent_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -51,10 +52,9 @@ public class DeleteEventToolTests
         var tool = new DeleteEventTool(regExp.Instance(), factExp.Instance(),
             NullLogger<DeleteEventTool>.Instance);
 
-        var result = await tool.DeleteEvent("ev-1", "nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.DeleteEvent("ev-1", "nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 

--- a/src/CalendarMcp.Tests/Tools/GetCalendarEventDetailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetCalendarEventDetailsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -14,49 +15,46 @@ public class GetCalendarEventDetailsToolTests
     private const string TestTimeZone = "America/Chicago";
 
     [TestMethod]
-    public async Task GetCalendarEventDetails_InvalidTimeZone_ReturnsError()
+    public async Task GetCalendarEventDetails_InvalidTimeZone_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetCalendarEventDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventDetailsTool>.Instance);
 
-        var result = await tool.GetCalendarEventDetails("Invalid/Zone", "acc-1", "cal-1", "ev-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("Invalid IANA timezone"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEventDetails("Invalid/Zone", "acc-1", "cal-1", "ev-1"));
+        Assert.IsTrue(ex.Message.Contains("Invalid IANA timezone"));
     }
 
     [TestMethod]
-    public async Task GetCalendarEventDetails_EmptyAccountId_ReturnsError()
+    public async Task GetCalendarEventDetails_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetCalendarEventDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventDetailsTool>.Instance);
 
-        var result = await tool.GetCalendarEventDetails(TestTimeZone, "", "cal-1", "ev-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEventDetails(TestTimeZone, "", "cal-1", "ev-1"));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetCalendarEventDetails_EmptyEventId_ReturnsError()
+    public async Task GetCalendarEventDetails_EmptyEventId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetCalendarEventDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventDetailsTool>.Instance);
 
-        var result = await tool.GetCalendarEventDetails(TestTimeZone, "acc-1", "cal-1", "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("eventId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEventDetails(TestTimeZone, "acc-1", "cal-1", ""));
+        Assert.AreEqual("eventId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetCalendarEventDetails_AccountNotFound_ReturnsError()
+    public async Task GetCalendarEventDetails_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -66,15 +64,14 @@ public class GetCalendarEventDetailsToolTests
         var tool = new GetCalendarEventDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventDetailsTool>.Instance);
 
-        var result = await tool.GetCalendarEventDetails(TestTimeZone, "nonexistent", "cal-1", "ev-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEventDetails(TestTimeZone, "nonexistent", "cal-1", "ev-1"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
     [TestMethod]
-    public async Task GetCalendarEventDetails_EventNotFound_ReturnsError()
+    public async Task GetCalendarEventDetails_EventNotFound_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
 
@@ -92,10 +89,9 @@ public class GetCalendarEventDetailsToolTests
         var tool = new GetCalendarEventDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventDetailsTool>.Instance);
 
-        var result = await tool.GetCalendarEventDetails(TestTimeZone, "acc-1", "cal-1", "missing");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("not found"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEventDetails(TestTimeZone, "acc-1", "cal-1", "missing"));
+        Assert.IsTrue(ex.Message.Contains("not found"));
         regExp.Verify();
         factExp.Verify();
         provExp.Verify();

--- a/src/CalendarMcp.Tests/Tools/GetCalendarEventsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetCalendarEventsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -16,21 +17,20 @@ public class GetCalendarEventsToolTests
     private const string TestTimeZone = "America/Chicago";
 
     [TestMethod]
-    public async Task GetCalendarEvents_InvalidTimeZone_ReturnsError()
+    public async Task GetCalendarEvents_InvalidTimeZone_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventsTool>.Instance);
 
-        var result = await tool.GetCalendarEvents("Invalid/Zone", Start, End);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("Invalid IANA timezone"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEvents("Invalid/Zone", Start, End));
+        Assert.IsTrue(ex.Message.Contains("Invalid IANA timezone"));
     }
 
     [TestMethod]
-    public async Task GetCalendarEvents_AccountNotFound_ReturnsError()
+    public async Task GetCalendarEvents_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -40,10 +40,9 @@ public class GetCalendarEventsToolTests
         var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventsTool>.Instance);
 
-        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, "nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEvents(TestTimeZone, Start, End, "nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
@@ -102,31 +101,29 @@ public class GetCalendarEventsToolTests
     }
 
     [TestMethod]
-    public async Task GetCalendarEvents_NullAccountId_ReturnsValidationError()
+    public async Task GetCalendarEvents_NullAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventsTool>.Instance);
 
-        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, null);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEvents(TestTimeZone, Start, End, null));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetCalendarEvents_EmptyAccountId_ReturnsValidationError()
+    public async Task GetCalendarEvents_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventsTool>.Instance);
 
-        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEvents(TestTimeZone, Start, End, ""));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
@@ -177,7 +174,7 @@ public class GetCalendarEventsToolTests
     }
 
     [TestMethod]
-    public async Task GetCalendarEvents_NullAccountIdWithCalendarId_NoMatch_ReturnsError()
+    public async Task GetCalendarEvents_NullAccountIdWithCalendarId_NoMatch_ThrowsMcpException()
     {
         var acc1 = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
         var calendars = new List<CalendarInfo> { TestData.CreateCalendar(id: "cal-other", accountId: "acc-1") };
@@ -195,10 +192,9 @@ public class GetCalendarEventsToolTests
         var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventsTool>.Instance);
 
-        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, null, "cal-missing");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("No calendar found with id 'cal-missing'"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEvents(TestTimeZone, Start, End, null, "cal-missing"));
+        Assert.IsTrue(ex.Message.Contains("No calendar found with id 'cal-missing'"));
 
         regExp.Verify();
         factExp.Verify();
@@ -206,7 +202,7 @@ public class GetCalendarEventsToolTests
     }
 
     [TestMethod]
-    public async Task GetCalendarEvents_NullAccountIdWithCalendarId_AmbiguousCalendarId_ReturnsError()
+    public async Task GetCalendarEvents_NullAccountIdWithCalendarId_AmbiguousCalendarId_ThrowsMcpException()
     {
         var acc1 = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
         var acc2 = TestData.CreateAccount(id: "acc-2", provider: "google");
@@ -231,10 +227,9 @@ public class GetCalendarEventsToolTests
         var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetCalendarEventsTool>.Instance);
 
-        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, null, "cal-shared");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("exists in multiple accounts"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetCalendarEvents(TestTimeZone, Start, End, null, "cal-shared"));
+        Assert.IsTrue(ex.Message.Contains("exists in multiple accounts"));
 
         regExp.Verify();
         factExp.Verify();

--- a/src/CalendarMcp.Tests/Tools/GetContextualEmailSummaryToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetContextualEmailSummaryToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,7 +13,7 @@ namespace CalendarMcp.Tests.Tools;
 public class GetContextualEmailSummaryToolTests
 {
     [TestMethod]
-    public async Task GetContextualEmailSummary_NoAccounts_ReturnsError()
+    public async Task GetContextualEmailSummary_NoAccounts_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAllAccountsAsync()
@@ -22,10 +23,9 @@ public class GetContextualEmailSummaryToolTests
         var tool = new GetContextualEmailSummaryTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetContextualEmailSummaryTool>.Instance);
 
-        var result = await tool.GetContextualEmailSummary();
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("No accounts configured", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetContextualEmailSummary());
+        Assert.AreEqual("No accounts configured", ex.Message);
         regExp.Verify();
     }
 

--- a/src/CalendarMcp.Tests/Tools/GetEmailAttachmentToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetEmailAttachmentToolTests.cs
@@ -5,6 +5,7 @@ using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -69,7 +70,7 @@ public class GetEmailAttachmentToolTests
     }
 
     [TestMethod]
-    public async Task InlineMode_OverCap_ReturnsError()
+    public async Task InlineMode_OverCap_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
         // 2 MB > 1 MB inline cap.
@@ -81,14 +82,14 @@ public class GetEmailAttachmentToolTests
         var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
 
-        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "inline");
-        var error = JsonDocument.Parse(json).RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("inline mode is capped", StringComparison.Ordinal) ?? false);
-        Assert.IsTrue(error?.Contains("stash", StringComparison.Ordinal) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "inline"));
+        Assert.IsTrue(ex.Message.Contains("inline mode is capped", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("stash", StringComparison.Ordinal));
     }
 
     [TestMethod]
-    public async Task ProviderReturnsNull_BubblesAsError()
+    public async Task ProviderReturnsNull_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
         var (regExp, factExp, _) = WireProviderForFetch(account, "msg-1", "missing", null);
@@ -96,22 +97,22 @@ public class GetEmailAttachmentToolTests
         var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
 
-        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "missing");
-        var error = JsonDocument.Parse(json).RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("not found", StringComparison.Ordinal) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailAttachment("acc-1", "msg-1", "missing"));
+        Assert.IsTrue(ex.Message.Contains("not found", StringComparison.Ordinal));
     }
 
     [TestMethod]
-    public async Task InvalidMode_ReturnsError()
+    public async Task InvalidMode_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetEmailAttachmentTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<GetEmailAttachmentTool>.Instance);
 
-        var json = await tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "weird");
-        var error = JsonDocument.Parse(json).RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("invalid", StringComparison.OrdinalIgnoreCase) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailAttachment("acc-1", "msg-1", "att-1", "weird"));
+        Assert.IsTrue(ex.Message.Contains("invalid", StringComparison.OrdinalIgnoreCase));
     }
 
     private static (

--- a/src/CalendarMcp.Tests/Tools/GetEmailDetailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetEmailDetailsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,35 +13,33 @@ namespace CalendarMcp.Tests.Tools;
 public class GetEmailDetailsToolTests
 {
     [TestMethod]
-    public async Task GetEmailDetails_EmptyAccountId_ReturnsError()
+    public async Task GetEmailDetails_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetEmailDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetEmailDetailsTool>.Instance);
 
-        var result = await tool.GetEmailDetails("", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailDetails("", "email-1"));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetEmailDetails_EmptyEmailId_ReturnsError()
+    public async Task GetEmailDetails_EmptyEmailId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetEmailDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetEmailDetailsTool>.Instance);
 
-        var result = await tool.GetEmailDetails("acc-1", "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("emailId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailDetails("acc-1", ""));
+        Assert.AreEqual("emailId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetEmailDetails_AccountNotFound_ReturnsError()
+    public async Task GetEmailDetails_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -50,15 +49,14 @@ public class GetEmailDetailsToolTests
         var tool = new GetEmailDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetEmailDetailsTool>.Instance);
 
-        var result = await tool.GetEmailDetails("nonexistent", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailDetails("nonexistent", "email-1"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
     [TestMethod]
-    public async Task GetEmailDetails_EmailNotFound_ReturnsError()
+    public async Task GetEmailDetails_EmailNotFound_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
 
@@ -76,10 +74,9 @@ public class GetEmailDetailsToolTests
         var tool = new GetEmailDetailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetEmailDetailsTool>.Instance);
 
-        var result = await tool.GetEmailDetails("acc-1", "missing-email");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("not found"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmailDetails("acc-1", "missing-email"));
+        Assert.IsTrue(ex.Message.Contains("not found"));
         regExp.Verify();
         factExp.Verify();
         provExp.Verify();

--- a/src/CalendarMcp.Tests/Tools/GetEmailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetEmailsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -42,7 +43,7 @@ public class GetEmailsToolTests
     }
 
     [TestMethod]
-    public async Task GetEmails_AccountNotFound_ReturnsError()
+    public async Task GetEmails_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -52,10 +53,9 @@ public class GetEmailsToolTests
         var tool = new GetEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetEmailsTool>.Instance);
 
-        var result = await tool.GetEmails("nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmails("nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
@@ -90,7 +90,7 @@ public class GetEmailsToolTests
     }
 
     [TestMethod]
-    public async Task GetEmails_NoAccounts_ReturnsError()
+    public async Task GetEmails_NoAccounts_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAllAccountsAsync()
@@ -100,10 +100,9 @@ public class GetEmailsToolTests
         var tool = new GetEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetEmailsTool>.Instance);
 
-        var result = await tool.GetEmails();
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("No accounts found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetEmails());
+        Assert.AreEqual("No accounts found", ex.Message);
         regExp.Verify();
     }
 }

--- a/src/CalendarMcp.Tests/Tools/GetUnsubscribeInfoToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetUnsubscribeInfoToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,35 +13,33 @@ namespace CalendarMcp.Tests.Tools;
 public class GetUnsubscribeInfoToolTests
 {
     [TestMethod]
-    public async Task GetUnsubscribeInfo_EmptyAccountId_ReturnsError()
+    public async Task GetUnsubscribeInfo_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetUnsubscribeInfoTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetUnsubscribeInfoTool>.Instance);
 
-        var result = await tool.GetUnsubscribeInfo("", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetUnsubscribeInfo("", "email-1"));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetUnsubscribeInfo_EmptyEmailId_ReturnsError()
+    public async Task GetUnsubscribeInfo_EmptyEmailId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new GetUnsubscribeInfoTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetUnsubscribeInfoTool>.Instance);
 
-        var result = await tool.GetUnsubscribeInfo("acc-1", "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("emailId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetUnsubscribeInfo("acc-1", ""));
+        Assert.AreEqual("emailId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task GetUnsubscribeInfo_AccountNotFound_ReturnsError()
+    public async Task GetUnsubscribeInfo_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -50,15 +49,14 @@ public class GetUnsubscribeInfoToolTests
         var tool = new GetUnsubscribeInfoTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetUnsubscribeInfoTool>.Instance);
 
-        var result = await tool.GetUnsubscribeInfo("nonexistent", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetUnsubscribeInfo("nonexistent", "email-1"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
     [TestMethod]
-    public async Task GetUnsubscribeInfo_EmailNotFound_ReturnsError()
+    public async Task GetUnsubscribeInfo_EmailNotFound_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
 
@@ -76,10 +74,9 @@ public class GetUnsubscribeInfoToolTests
         var tool = new GetUnsubscribeInfoTool(regExp.Instance(), factExp.Instance(),
             NullLogger<GetUnsubscribeInfoTool>.Instance);
 
-        var result = await tool.GetUnsubscribeInfo("acc-1", "missing");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("not found"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.GetUnsubscribeInfo("acc-1", "missing"));
+        Assert.IsTrue(ex.Message.Contains("not found"));
         regExp.Verify();
         factExp.Verify();
         provExp.Verify();

--- a/src/CalendarMcp.Tests/Tools/ListAccountsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/ListAccountsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -58,20 +59,18 @@ public class ListAccountsToolTests
     }
 
     [TestMethod]
-    public async Task ListAccounts_Exception_ReturnsErrorJson()
+    public async Task ListAccounts_Exception_ThrowsGenericMcpException()
     {
         var registryExpectations = new IAccountRegistryCreateExpectations();
         registryExpectations.Setups.GetAllAccountsAsync()
-            .Callback(() => throw new InvalidOperationException("Test error"));
+            .Callback(() => throw new InvalidOperationException("Sensitive registry detail"));
 
         var registry = registryExpectations.Instance();
         var tool = new ListAccountsTool(registry, NullLogger<ListAccountsTool>.Instance);
 
-        var result = await tool.ListAccounts();
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Failed to list accounts", doc.RootElement.GetProperty("error").GetString());
-        Assert.AreEqual("Test error", doc.RootElement.GetProperty("message").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(() => tool.ListAccounts());
+        Assert.AreEqual("Failed to list accounts.", ex.Message);
+        Assert.IsFalse(ex.Message.Contains("Sensitive registry detail"));
 
         registryExpectations.Verify();
     }

--- a/src/CalendarMcp.Tests/Tools/ListCalendarsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/ListCalendarsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -42,7 +43,7 @@ public class ListCalendarsToolTests
     }
 
     [TestMethod]
-    public async Task ListCalendars_AccountNotFound_ReturnsError()
+    public async Task ListCalendars_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -52,10 +53,9 @@ public class ListCalendarsToolTests
         var tool = new ListCalendarsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<ListCalendarsTool>.Instance);
 
-        var result = await tool.ListCalendars("nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.ListCalendars("nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 

--- a/src/CalendarMcp.Tests/Tools/MarkEmailAsReadToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/MarkEmailAsReadToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,35 +13,33 @@ namespace CalendarMcp.Tests.Tools;
 public class MarkEmailAsReadToolTests
 {
     [TestMethod]
-    public async Task MarkEmailAsRead_EmptyAccountId_ReturnsError()
+    public async Task MarkEmailAsRead_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new MarkEmailAsReadTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MarkEmailAsReadTool>.Instance);
 
-        var result = await tool.MarkEmailAsRead("", "email-1", true);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MarkEmailAsRead("", "email-1", true));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task MarkEmailAsRead_EmptyEmailId_ReturnsError()
+    public async Task MarkEmailAsRead_EmptyEmailId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new MarkEmailAsReadTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MarkEmailAsReadTool>.Instance);
 
-        var result = await tool.MarkEmailAsRead("acc-1", "", true);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("emailId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MarkEmailAsRead("acc-1", "", true));
+        Assert.AreEqual("emailId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task MarkEmailAsRead_AccountNotFound_ReturnsError()
+    public async Task MarkEmailAsRead_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -50,10 +49,9 @@ public class MarkEmailAsReadToolTests
         var tool = new MarkEmailAsReadTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MarkEmailAsReadTool>.Instance);
 
-        var result = await tool.MarkEmailAsRead("nonexistent", "email-1", true);
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MarkEmailAsRead("nonexistent", "email-1", true));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 

--- a/src/CalendarMcp.Tests/Tools/MoveEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/MoveEmailToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,49 +13,46 @@ namespace CalendarMcp.Tests.Tools;
 public class MoveEmailToolTests
 {
     [TestMethod]
-    public async Task MoveEmail_EmptyAccountId_ReturnsError()
+    public async Task MoveEmail_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new MoveEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MoveEmailTool>.Instance);
 
-        var result = await tool.MoveEmail("", "email-1", "archive");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MoveEmail("", "email-1", "archive"));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task MoveEmail_EmptyEmailId_ReturnsError()
+    public async Task MoveEmail_EmptyEmailId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new MoveEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MoveEmailTool>.Instance);
 
-        var result = await tool.MoveEmail("acc-1", "", "archive");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("emailId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MoveEmail("acc-1", "", "archive"));
+        Assert.AreEqual("emailId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task MoveEmail_EmptyDestination_ReturnsError()
+    public async Task MoveEmail_EmptyDestination_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new MoveEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MoveEmailTool>.Instance);
 
-        var result = await tool.MoveEmail("acc-1", "email-1", "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("destination is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MoveEmail("acc-1", "email-1", ""));
+        Assert.AreEqual("destination is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task MoveEmail_AccountNotFound_ReturnsError()
+    public async Task MoveEmail_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -64,10 +62,9 @@ public class MoveEmailToolTests
         var tool = new MoveEmailTool(regExp.Instance(), factExp.Instance(),
             NullLogger<MoveEmailTool>.Instance);
 
-        var result = await tool.MoveEmail("nonexistent", "email-1", "archive");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.MoveEmail("nonexistent", "email-1", "archive"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 

--- a/src/CalendarMcp.Tests/Tools/RespondToEventToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/RespondToEventToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,17 +13,16 @@ namespace CalendarMcp.Tests.Tools;
 public class RespondToEventToolTests
 {
     [TestMethod]
-    public async Task RespondToEvent_InvalidResponse_ReturnsError()
+    public async Task RespondToEvent_InvalidResponse_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new RespondToEventTool(regExp.Instance(), factExp.Instance(),
             NullLogger<RespondToEventTool>.Instance);
 
-        var result = await tool.RespondToEvent("ev-1", "invalid");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("Invalid response type"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.RespondToEvent("ev-1", "invalid"));
+        Assert.IsTrue(ex.Message.Contains("Invalid response type"));
     }
 
     [TestMethod]
@@ -59,7 +59,7 @@ public class RespondToEventToolTests
     }
 
     [TestMethod]
-    public async Task RespondToEvent_AccountNotFound_ReturnsError()
+    public async Task RespondToEvent_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -69,10 +69,9 @@ public class RespondToEventToolTests
         var tool = new RespondToEventTool(regExp.Instance(), factExp.Instance(),
             NullLogger<RespondToEventTool>.Instance);
 
-        var result = await tool.RespondToEvent("ev-1", "accept", "nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.RespondToEvent("ev-1", "accept", "nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 }

--- a/src/CalendarMcp.Tests/Tools/SearchEmailsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SearchEmailsToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -12,21 +13,20 @@ namespace CalendarMcp.Tests.Tools;
 public class SearchEmailsToolTests
 {
     [TestMethod]
-    public async Task SearchEmails_EmptyQuery_ReturnsError()
+    public async Task SearchEmails_EmptyQuery_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SearchEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SearchEmailsTool>.Instance);
 
-        var result = await tool.SearchEmails("");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Parameter 'query' is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SearchEmails(""));
+        Assert.AreEqual("query is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task SearchEmails_AccountNotFound_ReturnsError()
+    public async Task SearchEmails_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -36,10 +36,9 @@ public class SearchEmailsToolTests
         var tool = new SearchEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SearchEmailsTool>.Instance);
 
-        var result = await tool.SearchEmails("test query", "nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SearchEmails("test query", "nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
@@ -125,7 +124,7 @@ public class SearchEmailsToolTests
     }
 
     [TestMethod]
-    public async Task SearchEmails_NoAccounts_ReturnsError()
+    public async Task SearchEmails_NoAccounts_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAllAccountsAsync()
@@ -135,10 +134,9 @@ public class SearchEmailsToolTests
         var tool = new SearchEmailsTool(regExp.Instance(), factExp.Instance(),
             NullLogger<SearchEmailsTool>.Instance);
 
-        var result = await tool.SearchEmails("test");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("No accounts found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SearchEmails("test"));
+        Assert.AreEqual("No accounts found", ex.Message);
         regExp.Verify();
     }
 }

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolAttachmentIdTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolAttachmentIdTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -78,7 +79,7 @@ public class SendEmailToolAttachmentIdTests
     }
 
     [TestMethod]
-    public async Task SendEmail_UnknownAttachmentId_ReturnsError()
+    public async Task SendEmail_UnknownAttachmentId_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
 
@@ -92,20 +93,19 @@ public class SendEmailToolAttachmentIdTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(
-            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<OutboundEmailAttachment>
-            {
-                new() { AttachmentId = "does-not-exist" },
-            });
-
-        var error = JsonDocument.Parse(result).RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("does-not-exist", StringComparison.Ordinal) ?? false);
-        Assert.IsTrue(error?.Contains("unknown or expired", StringComparison.Ordinal) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(
+                new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+                attachments: new List<OutboundEmailAttachment>
+                {
+                    new() { AttachmentId = "does-not-exist" },
+                }));
+        Assert.IsTrue(ex.Message.Contains("does-not-exist", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("unknown or expired", StringComparison.Ordinal));
     }
 
     [TestMethod]
-    public async Task SendEmail_BothInlineAndId_ReturnsError_AndDoesNotConsume()
+    public async Task SendEmail_BothInlineAndId_ThrowsMcpException_AndDoesNotConsume()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
         var store = new TestAttachmentStore();
@@ -117,38 +117,36 @@ public class SendEmailToolAttachmentIdTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(), store,
             NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(
-            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<OutboundEmailAttachment>
-            {
-                new() { AttachmentId = "u1", Name = "x.bin", Base64Content = "AQ==" },
-            });
-
-        var error = JsonDocument.Parse(result).RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("not both", StringComparison.OrdinalIgnoreCase) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(
+                new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+                attachments: new List<OutboundEmailAttachment>
+                {
+                    new() { AttachmentId = "u1", Name = "x.bin", Base64Content = "AQ==" },
+                }));
+        Assert.IsTrue(ex.Message.Contains("not both", StringComparison.OrdinalIgnoreCase));
 
         // Store entry must NOT have been consumed — shape errors precede consumption.
         Assert.AreEqual(0, store.ConsumedIds.Count);
     }
 
     [TestMethod]
-    public async Task SendEmail_NeitherInlineNorId_ReturnsError()
+    public async Task SendEmail_NeitherInlineNorId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(
-            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<OutboundEmailAttachment>
-            {
-                new() { Name = "x.bin" },
-            });
-
-        var error = JsonDocument.Parse(result).RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("base64Content", StringComparison.Ordinal) ?? false);
-        Assert.IsTrue(error?.Contains("attachmentId", StringComparison.Ordinal) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(
+                new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+                attachments: new List<OutboundEmailAttachment>
+                {
+                    new() { Name = "x.bin" },
+                }));
+        Assert.IsTrue(ex.Message.Contains("base64Content", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("attachmentId", StringComparison.Ordinal));
     }
 
     private static (

--- a/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/SendEmailToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -45,7 +46,7 @@ public class SendEmailToolTests
     }
 
     [TestMethod]
-    public async Task SendEmail_AccountNotFound_ReturnsError()
+    public async Task SendEmail_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -55,17 +56,18 @@ public class SendEmailToolTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(new List<string> { "to@example.com" }, "Subject", "Body", "nonexistent");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(new List<string> { "to@example.com" }, "Subject", "Body", "nonexistent"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
     [TestMethod]
-    public async Task SendEmail_NoAccountNoMatch_ReturnsError()
+    public async Task SendEmail_NoAccountNoMatch_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountsByDomain("unknown.com")
+            .ReturnValue([]);
         regExp.Setups.GetAllAccountsAsync()
             .ReturnValue(Task.FromResult<IEnumerable<AccountInfo>>([]));
 
@@ -73,26 +75,23 @@ public class SendEmailToolTests
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(new List<string> { "to@unknown.com" }, "Subject", "Body");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(new List<string> { "to@unknown.com" }, "Subject", "Body"));
+        Assert.AreEqual("No enabled account available to send email", ex.Message);
         regExp.Verify();
     }
 
     [TestMethod]
-    public async Task SendEmail_EmptyToList_ReturnsError()
+    public async Task SendEmail_EmptyToList_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail([], "Subject", "Body", "acc-1");
-        var doc = JsonDocument.Parse(result);
-
-        var error = doc.RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("recipient", StringComparison.OrdinalIgnoreCase) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail([], "Subject", "Body", "acc-1"));
+        Assert.IsTrue(ex.Message.Contains("recipient", StringComparison.OrdinalIgnoreCase));
     }
 
     [TestMethod]
@@ -137,47 +136,43 @@ public class SendEmailToolTests
     }
 
     [TestMethod]
-    public async Task SendEmail_AttachmentMissingName_ReturnsError()
+    public async Task SendEmail_AttachmentMissingName_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(
-            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<OutboundEmailAttachment>
-            {
-                new() { Name = "", Base64Content = "aGVsbG8=" },
-            });
-
-        var doc = JsonDocument.Parse(result);
-        var error = doc.RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("name is required", StringComparison.OrdinalIgnoreCase) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(
+                new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+                attachments: new List<OutboundEmailAttachment>
+                {
+                    new() { Name = "", Base64Content = "aGVsbG8=" },
+                }));
+        Assert.IsTrue(ex.Message.Contains("name is required", StringComparison.OrdinalIgnoreCase));
     }
 
     [TestMethod]
-    public async Task SendEmail_AttachmentMissingContent_ReturnsError()
+    public async Task SendEmail_AttachmentMissingContent_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = new SendEmailTool(regExp.Instance(), factExp.Instance(),
             new TestAttachmentStore(), NullLogger<SendEmailTool>.Instance);
 
-        var result = await tool.SendEmail(
-            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<OutboundEmailAttachment>
-            {
-                new() { Name = "x.txt", Base64Content = "" },
-            });
-
-        var doc = JsonDocument.Parse(result);
-        var error = doc.RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("base64Content", StringComparison.OrdinalIgnoreCase) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(
+                new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+                attachments: new List<OutboundEmailAttachment>
+                {
+                    new() { Name = "x.txt", Base64Content = "" },
+                }));
+        Assert.IsTrue(ex.Message.Contains("base64Content", StringComparison.OrdinalIgnoreCase));
     }
 
     [TestMethod]
-    public async Task SendEmail_AttachmentExceedsTotalCap_ReturnsError()
+    public async Task SendEmail_AttachmentExceedsTotalCap_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
@@ -186,15 +181,13 @@ public class SendEmailToolTests
 
         // 35 MB of base64 chars decodes to ~26 MB, just over the 25 MB cap.
         var bigBase64 = new string('A', 35 * 1024 * 1024);
-        var result = await tool.SendEmail(
-            new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
-            attachments: new List<OutboundEmailAttachment>
-            {
-                new() { Name = "a.bin", Base64Content = bigBase64 },
-            });
-
-        var doc = JsonDocument.Parse(result);
-        var error = doc.RootElement.GetProperty("error").GetString();
-        Assert.IsTrue(error?.Contains("exceeds", StringComparison.OrdinalIgnoreCase) ?? false);
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.SendEmail(
+                new List<string> { "to@example.com" }, "Subject", "Body", "acc-1",
+                attachments: new List<OutboundEmailAttachment>
+                {
+                    new() { Name = "a.bin", Base64Content = bigBase64 },
+                }));
+        Assert.IsTrue(ex.Message.Contains("exceeds", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/CalendarMcp.Tests/Tools/UnsubscribeFromEmailToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/UnsubscribeFromEmailToolTests.cs
@@ -5,6 +5,7 @@ using CalendarMcp.Core.Tools;
 using CalendarMcp.Core.Utilities;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -23,33 +24,31 @@ public class UnsubscribeFromEmailToolTests
     }
 
     [TestMethod]
-    public async Task UnsubscribeFromEmail_EmptyAccountId_ReturnsError()
+    public async Task UnsubscribeFromEmail_EmptyAccountId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = CreateTool(regExp.Instance(), factExp.Instance());
 
-        var result = await tool.UnsubscribeFromEmail("", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("accountId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.UnsubscribeFromEmail("", "email-1"));
+        Assert.AreEqual("accountId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task UnsubscribeFromEmail_EmptyEmailId_ReturnsError()
+    public async Task UnsubscribeFromEmail_EmptyEmailId_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = CreateTool(regExp.Instance(), factExp.Instance());
 
-        var result = await tool.UnsubscribeFromEmail("acc-1", "");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("emailId is required", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.UnsubscribeFromEmail("acc-1", ""));
+        Assert.AreEqual("emailId is required", ex.Message);
     }
 
     [TestMethod]
-    public async Task UnsubscribeFromEmail_AccountNotFound_ReturnsError()
+    public async Task UnsubscribeFromEmail_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -58,15 +57,14 @@ public class UnsubscribeFromEmailToolTests
         var factExp = new IProviderServiceFactoryCreateExpectations();
         var tool = CreateTool(regExp.Instance(), factExp.Instance());
 
-        var result = await tool.UnsubscribeFromEmail("nonexistent", "email-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.UnsubscribeFromEmail("nonexistent", "email-1"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 
     [TestMethod]
-    public async Task UnsubscribeFromEmail_EmailNotFound_ReturnsError()
+    public async Task UnsubscribeFromEmail_EmailNotFound_ThrowsMcpException()
     {
         var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
 
@@ -83,10 +81,9 @@ public class UnsubscribeFromEmailToolTests
 
         var tool = CreateTool(regExp.Instance(), factExp.Instance());
 
-        var result = await tool.UnsubscribeFromEmail("acc-1", "missing");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.IsTrue(doc.RootElement.GetProperty("error").GetString()!.Contains("not found"));
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.UnsubscribeFromEmail("acc-1", "missing"));
+        Assert.IsTrue(ex.Message.Contains("not found"));
         regExp.Verify();
         factExp.Verify();
         provExp.Verify();

--- a/src/CalendarMcp.Tests/Tools/UpdateEventToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/UpdateEventToolTests.cs
@@ -4,6 +4,7 @@ using CalendarMcp.Core.Services;
 using CalendarMcp.Core.Tools;
 using CalendarMcp.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using Rocks;
 
 namespace CalendarMcp.Tests.Tools;
@@ -48,7 +49,7 @@ public class UpdateEventToolTests
     }
 
     [TestMethod]
-    public async Task UpdateEvent_AccountNotFound_ReturnsError()
+    public async Task UpdateEvent_AccountNotFound_ThrowsMcpException()
     {
         var regExp = new IAccountRegistryCreateExpectations();
         regExp.Setups.GetAccountAsync("nonexistent")
@@ -58,10 +59,9 @@ public class UpdateEventToolTests
         var tool = new UpdateEventTool(regExp.Instance(), factExp.Instance(),
             NullLogger<UpdateEventTool>.Instance);
 
-        var result = await tool.UpdateEvent("nonexistent", "cal-1", "ev-1");
-        var doc = JsonDocument.Parse(result);
-
-        Assert.AreEqual("Account 'nonexistent' not found", doc.RootElement.GetProperty("error").GetString());
+        var ex = await Assert.ThrowsExactlyAsync<McpException>(
+            () => tool.UpdateEvent("nonexistent", "cal-1", "ev-1"));
+        Assert.AreEqual("Account 'nonexistent' not found", ex.Message);
         regExp.Verify();
     }
 }


### PR DESCRIPTION
## Summary

- Tools now signal errors via `McpException` so MCP clients see protocol-level errors (`isError: true`) rather than successful responses whose body contains an `error` field. Fixes the rockbot failure where calling a tool with a missing required parameter produced a 200-style success result with `{"error":"accountId is required"}` in the body — leaving callers unable to detect the malformed request.
- New `ToolGuard` helper centralizes the required-string and account-lookup checks used across ~27 tools.
- Three-tier error policy keeps provider/SDK exception detail off the wire:
  - **Tier 1 (validation)** — author-controlled messages propagate as-is (`"accountId is required"`, `"Account 'X' not found"`, etc.)
  - **Tier 2 (provider/SDK exceptions)** — caught, logged server-side, rethrown as a generic `McpException("Failed to <action>.", ex)`. Original `ex.Message` from Graph/Gmail/IMAP never reaches the remote.
  - **Tier 3 (operational state we describe ourselves)** — same treatment as Tier 1.
- Bulk tools (delete, move, mark-as-read) keep per-item failures inside the success body, but outer validation throws `McpException` and per-item provider exceptions are sanitized to a generic per-item error.
- Tests rewritten to assert `ThrowsExactlyAsync<McpException>` with message checks; added a regression in `DeleteEmailToolTests` proving provider exception messages do not leak through to `McpException.Message`.

Net diff: +741 / −1150 — the dedup removed ~400 lines.

Closes #54.

## Test plan

- [x] `dotnet build` — solution builds clean
- [x] `dotnet test` — all 243 tests pass
- [x] Manual review: confirmed no production code outside the tools parses the `{error: ...}` success-body shape (only `AdminEndpoints.cs` uses that shape, in its own HTTP responses — unrelated)
- [ ] Smoke test against rockbot: call a tool with a missing required parameter and confirm the response is now an MCP error rather than a success with embedded `error` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)