### PR TITLE
Add MCP server identity and GetGuide tool for progressive disclosure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,11 @@
 **/spikes
 **/installer
 **/*.md
+# Skills markdown files are embedded as MCP guide resources via the
+# CalendarMcp.Core.csproj <EmbeddedResource> item, so they must reach
+# the build context even though the rule above excludes documentation
+# markdown elsewhere in the repo.
+!src/CalendarMcp.Core/Skills/*.md
 **/LICENSE
 **/.gitignore
 **/.dockerignore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.6</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/CalendarMcp.Core/CalendarMcp.Core.csproj
+++ b/src/CalendarMcp.Core/CalendarMcp.Core.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Skills\*.md" />
+  </ItemGroup>
+
 </Project>

--- a/src/CalendarMcp.Core/CalendarMcp.Core.csproj
+++ b/src/CalendarMcp.Core/CalendarMcp.Core.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Skills\*.md" />
+    <EmbeddedResource Include="Skills/*.md" />
   </ItemGroup>
 
 </Project>

--- a/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
+++ b/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
@@ -13,7 +13,10 @@ public static class CalendarMcpServerOptions
     private const string Description =
         "Unified access to email, calendar, and contacts across Microsoft 365, " +
         "Google Workspace/Gmail, Outlook.com, and IMAP/SMTP mailboxes, plus " +
-        "read-only iCalendar (.ics) URLs and JSON-file calendar sources.";
+        "read-only iCalendar (.ics) URLs and JSON-file calendar sources. " +
+        "Call the GetGuide tool (no arguments) for the index of in-depth " +
+        "topical guides covering accounts, email, calendar, contacts, " +
+        "attachments, end-to-end scenarios, and per-provider behavior.";
 
     private const string Instructions = """
         Calendar MCP exposes email, calendar, and contacts tools across multiple

--- a/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
+++ b/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
@@ -14,7 +14,7 @@ public static class CalendarMcpServerOptions
         "Unified access to email, calendar, and contacts across Microsoft 365, " +
         "Google Workspace/Gmail, Outlook.com, and IMAP/SMTP mailboxes, plus " +
         "read-only iCalendar (.ics) URLs and JSON-file calendar sources. " +
-        "Call the GetGuide tool (no arguments) for the index of in-depth " +
+        "Call the get_guide tool (no arguments) for the index of in-depth " +
         "topical guides covering accounts, email, calendar, contacts, " +
         "attachments, end-to-end scenarios, and per-provider behavior.";
 
@@ -22,11 +22,11 @@ public static class CalendarMcpServerOptions
         Calendar MCP exposes email, calendar, and contacts tools across multiple
         personal-information providers. Capabilities vary per configured account.
 
-        Start by calling `ListAccounts` to discover which accounts are configured
+        Start by calling `list_accounts` to discover which accounts are configured
         and what each one supports (email / calendar / contacts, read-only or read-write).
         Use the returned accountId values when calling other tools.
 
-        For detailed how-to playbooks on specific topics, call the `GetGuide` tool.
+        For detailed how-to playbooks on specific topics, call the `get_guide` tool.
         Call it with no arguments (or name='index') to see the list of available guides,
         then call it again with a topic name to read that guide.
 

--- a/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
+++ b/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace CalendarMcp.Core.Configuration;
+
+/// <summary>
+/// Configures the MCP server's identity and orientation instructions.
+/// Shared by the stdio and HTTP server entry points so both report the same metadata.
+/// </summary>
+public static class CalendarMcpServerOptions
+{
+    private const string Description =
+        "Unified access to email, calendar, and contacts across Microsoft 365, " +
+        "Google Workspace/Gmail, Outlook.com, and IMAP/SMTP mailboxes, plus " +
+        "read-only iCalendar (.ics) URLs and JSON-file calendar sources.";
+
+    private const string Instructions = """
+        Calendar MCP exposes email, calendar, and contacts tools across multiple
+        personal-information providers. Capabilities vary per configured account.
+
+        Start by calling `ListAccounts` to discover which accounts are configured
+        and what each one supports (email / calendar / contacts, read-only or read-write).
+        Use the returned accountId values when calling other tools.
+
+        For detailed how-to playbooks on specific topics, call the `GetGuide` tool.
+        Call it with no arguments (or name='index') to see the list of available guides,
+        then call it again with a topic name to read that guide.
+
+        Provider capability summary:
+        - Microsoft 365 / Google Workspace / Outlook.com: email, calendar, contacts (read/write)
+        - IMAP + SMTP: email only (read/write)
+        - iCalendar (.ics) URL: calendar (read-only)
+        - JSON file: calendar plus optional email/contacts (read-only)
+        """;
+
+    public static void Configure(McpServerOptions options)
+    {
+        options.ServerInfo = new Implementation
+        {
+            Name = "calendar-mcp",
+            Title = "Calendar MCP",
+            Version = GetVersion(),
+            Description = Description,
+        };
+        options.ServerInstructions = Instructions;
+    }
+
+    private static string GetVersion()
+    {
+        var assembly = typeof(CalendarMcpServerOptions).Assembly;
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        var version = informational
+            ?? assembly.GetName().Version?.ToString(3)
+            ?? "0.0.0";
+
+        // Strip SourceLink-style "+<commit-sha>" suffix if present so the
+        // reported version is the clean semver from Directory.Build.props.
+        var plusIndex = version.IndexOf('+');
+        return plusIndex > 0 ? version[..plusIndex] : version;
+    }
+}

--- a/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CalendarMcp.Core/Configuration/ServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ public static class ServiceCollectionExtensions
         
         // Register MCP tools (method-based pattern - just register the classes)
         services.AddSingleton<ListAccountsTool>();
+        services.AddSingleton<GetGuideTool>();
         services.AddSingleton<GetEmailsTool>();
         services.AddSingleton<GetEmailDetailsTool>();
         services.AddSingleton<GetEmailAttachmentTool>();

--- a/src/CalendarMcp.Core/Skills/accounts.md
+++ b/src/CalendarMcp.Core/Skills/accounts.md
@@ -6,7 +6,7 @@ else you do here.
 
 ## Discover accounts first
 
-Call **`ListAccounts`** at the start of any new session. It returns:
+Call **`list_accounts`** at the start of any new session. It returns:
 
 ```json
 {
@@ -42,13 +42,13 @@ Use these fields to decide what's possible before calling other tools:
 - **`provider`** — informs behavior (Gmail uses labels, M365 uses folders,
   ICS is read-only, etc.). See `providers` for details.
 - **`domains`** — the email domains this account "owns." Used by
-  smart-routing in `SendEmail`.
+  smart-routing in `send_email`.
 - **`capabilities`** — which categories the account supports and whether
   they are read-only. Always check this before calling a write tool.
 
 ## Provider type values
 
-The `provider` field returned by `ListAccounts` uses these canonical
+The `provider` field returned by `list_accounts` uses these canonical
 strings:
 
 | Value | Description |
@@ -66,18 +66,18 @@ Most tools accept `accountId` as optional. When you omit it, the server
 either targets the first configured account or uses smart routing — both
 can silently target the wrong account. Treat the `accountId` parameter as
 effectively required for any tool that writes data
-(`SendEmail`, `CreateEvent`, `CreateContact`, `DeleteEmail`, etc.).
+(`send_email`, `create_event`, `create_contact`, `delete_email`, etc.).
 
 The exceptions where omitting `accountId` is fine:
 
-- `GetEmails`, `SearchEmails`, `ListCalendars`, `GetContacts`,
-  `SearchContacts` — these fan out across all enabled accounts when
+- `get_emails`, `search_emails`, `list_calendars`, `get_contacts`,
+  `search_contacts` — these fan out across all enabled accounts when
   `accountId` is omitted, which is often what you want.
 - `get_contextual_email_summary` — always fans out across all accounts.
 
 ## Capability checking before write operations
 
-Before calling a write tool (e.g. `CreateEvent`), confirm the chosen
+Before calling a write tool (e.g. `create_event`), confirm the chosen
 account isn't read-only for that category:
 
 ```text
@@ -86,12 +86,12 @@ if !capability || capability.readOnly == true:
   pick a different account (or surface an error to the user)
 ```
 
-This avoids calling `CreateEvent` against an `ics` or `json` account,
+This avoids calling `create_event` against an `ics` or `json` account,
 which will fail at the provider layer with a less helpful message.
 
-## Smart routing in `SendEmail`
+## Smart routing in `send_email`
 
-`SendEmail` accepts a missing `accountId`. When omitted:
+`send_email` accepts a missing `accountId`. When omitted:
 
 1. Extract domain from the first recipient (`to[0]` after `@`).
 2. Look up accounts whose `domains` array contains that domain.
@@ -106,15 +106,15 @@ received the original).
 
 ## Multi-account fan-out
 
-`GetEmails`, `SearchEmails`, and `get_contextual_email_summary` query
+`get_emails`, `search_emails`, and `get_contextual_email_summary` query
 all accounts in parallel and merge results, sorting newest-first. Each
 returned email carries its own `accountId` — use that to call
-`GetEmailDetails`, `MoveEmail`, etc. Never assume the original
+`get_email_details`, `move_email`, etc. Never assume the original
 `accountId` you might have used for filtering; always echo it back from
 the result.
 
 ## Disabled accounts
 
-Accounts can be marked disabled via the admin UI. `ListAccounts`
+Accounts can be marked disabled via the admin UI. `list_accounts`
 returns only enabled accounts. If a previously-known `accountId` stops
-working, re-call `ListAccounts` to refresh.
+working, re-call `list_accounts` to refresh.

--- a/src/CalendarMcp.Core/Skills/accounts.md
+++ b/src/CalendarMcp.Core/Skills/accounts.md
@@ -1,0 +1,120 @@
+# Accounts
+
+Every tool in Calendar MCP operates against one or more configured
+accounts. Understanding the account model is prerequisite to anything
+else you do here.
+
+## Discover accounts first
+
+Call **`ListAccounts`** at the start of any new session. It returns:
+
+```json
+{
+  "accounts": [
+    {
+      "accountId": "work-m365",
+      "provider": "microsoft365",
+      "displayName": "Work (M365)",
+      "domains": ["lhotka.net"],
+      "capabilities": [
+        { "name": "calendar", "readOnly": false },
+        { "name": "email",    "readOnly": false },
+        { "name": "contacts", "readOnly": false }
+      ]
+    },
+    {
+      "accountId": "family-cal",
+      "provider": "ics",
+      "displayName": "Family Calendar",
+      "domains": [],
+      "capabilities": [
+        { "name": "calendar", "readOnly": true }
+      ]
+    }
+  ]
+}
+```
+
+Use these fields to decide what's possible before calling other tools:
+
+- **`accountId`** — the only identifier other tools accept. Pass it
+  verbatim; don't reformat or guess.
+- **`provider`** — informs behavior (Gmail uses labels, M365 uses folders,
+  ICS is read-only, etc.). See `providers` for details.
+- **`domains`** — the email domains this account "owns." Used by
+  smart-routing in `SendEmail`.
+- **`capabilities`** — which categories the account supports and whether
+  they are read-only. Always check this before calling a write tool.
+
+## Provider type values
+
+The `provider` field returned by `ListAccounts` uses these canonical
+strings:
+
+| Value | Description |
+|---|---|
+| `microsoft365` | Microsoft 365 / Entra ID (Graph) |
+| `google` | Google Workspace / Gmail |
+| `outlook.com` | Consumer Outlook.com / Hotmail (Graph) |
+| `imap` | IMAP + SMTP (unattended mailboxes) |
+| `ics` | Subscribed iCalendar URL (calendar only, read-only) |
+| `json` | JSON file (read-only; calendar + optional email/contacts) |
+
+## Always pass `accountId` explicitly
+
+Most tools accept `accountId` as optional. When you omit it, the server
+either targets the first configured account or uses smart routing — both
+can silently target the wrong account. Treat the `accountId` parameter as
+effectively required for any tool that writes data
+(`SendEmail`, `CreateEvent`, `CreateContact`, `DeleteEmail`, etc.).
+
+The exceptions where omitting `accountId` is fine:
+
+- `GetEmails`, `SearchEmails`, `ListCalendars`, `GetContacts`,
+  `SearchContacts` — these fan out across all enabled accounts when
+  `accountId` is omitted, which is often what you want.
+- `get_contextual_email_summary` — always fans out across all accounts.
+
+## Capability checking before write operations
+
+Before calling a write tool (e.g. `CreateEvent`), confirm the chosen
+account isn't read-only for that category:
+
+```text
+capability = account.capabilities.find(c => c.name === "calendar")
+if !capability || capability.readOnly == true:
+  pick a different account (or surface an error to the user)
+```
+
+This avoids calling `CreateEvent` against an `ics` or `json` account,
+which will fail at the provider layer with a less helpful message.
+
+## Smart routing in `SendEmail`
+
+`SendEmail` accepts a missing `accountId`. When omitted:
+
+1. Extract domain from the first recipient (`to[0]` after `@`).
+2. Look up accounts whose `domains` array contains that domain.
+3. If exactly one matches, send from it.
+4. If multiple match, the first one is used (deterministic but arbitrary).
+5. If none match, the first configured account is used as fallback.
+
+This is convenient for casual replies but **unsafe for production
+workflows** — always pass `accountId` when correctness matters (e.g.
+sending from a specific persona, replying within the same account that
+received the original).
+
+## Multi-account fan-out
+
+`GetEmails`, `SearchEmails`, and `get_contextual_email_summary` query
+all accounts in parallel and merge results, sorting newest-first. Each
+returned email carries its own `accountId` — use that to call
+`GetEmailDetails`, `MoveEmail`, etc. Never assume the original
+`accountId` you might have used for filtering; always echo it back from
+the result.
+
+## Disabled accounts
+
+Accounts can be marked disabled via the admin UI. `ListAccounts`
+returns only enabled accounts. If a previously-known `accountId` stops
+working, re-call `ListAccounts` to refresh.

--- a/src/CalendarMcp.Core/Skills/attachments.md
+++ b/src/CalendarMcp.Core/Skills/attachments.md
@@ -1,0 +1,137 @@
+# Attachments
+
+Attachments are the most non-obvious part of Calendar MCP because the
+bytes generally **do not transit through the agent**. Two pathways
+exist; pick by direction.
+
+## Outbound (sending a file)
+
+`SendEmail` accepts `attachments[]` where each item has one of:
+
+- **`{ "attachmentId": "abc..." }`** — preferred. The bytes were
+  previously uploaded to the server's attachment store. Single-use:
+  consumed when `SendEmail` succeeds.
+- **`{ "name": "x.pdf", "base64Content": "...", "contentType": "..." }`** —
+  the agent encodes the file inline. Use only for very small files; the
+  total decoded payload per message is capped at **25 MB** by this
+  server, and most providers (M365/Outlook.com) cap each individual
+  attachment at **3 MB**.
+
+### Getting an `attachmentId` (HTTP server only)
+
+On the HTTP transport, the file is uploaded out-of-band:
+
+```http
+POST /attachments              ← multipart/form-data with the file
+→ 201 Created
+  { "attachmentId": "abc...", "name": "...", "contentType": "...",
+    "size": 123456, "expiresAt": "..." }
+```
+
+Then in the tool call:
+
+```json
+{
+  "tool": "SendEmail",
+  "arguments": {
+    "to": ["alice@example.com"],
+    "subject": "Q4 report",
+    "body": "<p>See attached.</p>",
+    "attachments": [{ "attachmentId": "abc..." }]
+  }
+}
+```
+
+Single-use: a successful send removes the ID. If the send fails, the ID
+remains usable until it expires; re-call `SendEmail`.
+
+The stdio transport does not have an HTTP upload endpoint, so on stdio
+you can only send via inline `base64Content` (small files), or by first
+calling `GetEmailAttachment` in `stash` mode to get an ID for forwarding.
+
+## Inbound (reading/forwarding a file)
+
+`GetEmailAttachment(accountId, emailId, attachmentId, mode="stash")`
+fetches an attachment from a received email. Two modes:
+
+### `mode="stash"` (default)
+
+Downloads the file into the server's attachment store and returns:
+
+```json
+{
+  "attachmentId": "xyz...",
+  "name": "report.pdf",
+  "contentType": "application/pdf",
+  "size": 4500000,
+  "expiresAt": "..."
+}
+```
+
+The bytes never round-trip through the agent. Hand the returned
+`attachmentId` directly to `SendEmail` to forward, or (HTTP server
+only) fetch the raw bytes via `GET /attachments/{id}` for non-MCP
+consumers.
+
+### `mode="inline"`
+
+Returns the bytes as `base64Content` in the response, capped at
+**1 MB**. Use only when the agent itself needs to read the file
+content (e.g., to OCR an image, parse a small PDF). Files larger than
+1 MB are refused with an error directing you to `stash` mode.
+
+## Forwarding flow (the most common pattern)
+
+```
+GetEmailDetails(accountId, emailId)
+  → response.attachments[]   // each has provider-side attachmentId
+
+For each attachment to forward:
+  GetEmailAttachment(accountId, emailId, attachmentId, mode="stash")
+  → response.attachmentId     // server-stash ID (different from provider's)
+
+SendEmail(
+  to=[<forward target>],
+  subject="...",
+  body="...",
+  attachments=[
+    { "attachmentId": <first server-stash ID> },
+    { "attachmentId": <second server-stash ID> }
+  ]
+)
+```
+
+Two distinct `attachmentId` namespaces exist:
+
+| Source | What it identifies | Where it's used |
+|---|---|---|
+| `GetEmailDetails.attachments[].attachmentId` | Provider-side ID (Gmail `part-0`, Graph opaque ID) | Input to `GetEmailAttachment` |
+| `GetEmailAttachment` (stash) / `POST /attachments` | Server-side store ID | Input to `SendEmail` |
+
+Don't mix them — passing a provider-side ID directly to `SendEmail`
+fails.
+
+## Size limits
+
+| Limit | Value | Enforced by |
+|---|---|---|
+| Total decoded payload per outbound message | 25 MB | This server |
+| Per-attachment cap | 3 MB (M365 / Outlook.com), 25 MB (Google) | Upstream provider |
+| Inline mode (`GetEmailAttachment mode="inline"`) | 1 MB | This server |
+| Server store per-item | Configurable (admin) | This server |
+
+Exceeding the total or per-attachment caps results in `McpException`
+with a descriptive message — surface it to the user; don't retry blindly.
+
+## Pitfalls
+
+- **Stash IDs are single-use** for sending; consume them by passing to
+  `SendEmail`. Re-stash if needed.
+- **IDs expire** (server-configurable, default minutes-to-hours). Treat
+  them as transient — get-and-use within the same conversation turn
+  when possible.
+- **Don't put bytes in tool responses unnecessarily.** Prefer `stash`
+  over `inline` whenever you don't need to inspect the content.
+- **No filename-only attachments.** Every entry must have either
+  `attachmentId` (with optional `name` override) or `base64Content`
+  with `name`.

--- a/src/CalendarMcp.Core/Skills/attachments.md
+++ b/src/CalendarMcp.Core/Skills/attachments.md
@@ -6,11 +6,11 @@ exist; pick by direction.
 
 ## Outbound (sending a file)
 
-`SendEmail` accepts `attachments[]` where each item has one of:
+`send_email` accepts `attachments[]` where each item has one of:
 
 - **`{ "attachmentId": "abc..." }`** — preferred. The bytes were
   previously uploaded to the server's attachment store. Single-use:
-  consumed when `SendEmail` succeeds.
+  consumed when `send_email` succeeds.
 - **`{ "name": "x.pdf", "base64Content": "...", "contentType": "..." }`** —
   the agent encodes the file inline. Use only for very small files; the
   total decoded payload per message is capped at **25 MB** by this
@@ -32,7 +32,7 @@ Then in the tool call:
 
 ```json
 {
-  "tool": "SendEmail",
+  "tool": "send_email",
   "arguments": {
     "to": ["alice@example.com"],
     "subject": "Q4 report",
@@ -43,15 +43,15 @@ Then in the tool call:
 ```
 
 Single-use: a successful send removes the ID. If the send fails, the ID
-remains usable until it expires; re-call `SendEmail`.
+remains usable until it expires; re-call `send_email`.
 
 The stdio transport does not have an HTTP upload endpoint, so on stdio
 you can only send via inline `base64Content` (small files), or by first
-calling `GetEmailAttachment` in `stash` mode to get an ID for forwarding.
+calling `get_email_attachment` in `stash` mode to get an ID for forwarding.
 
 ## Inbound (reading/forwarding a file)
 
-`GetEmailAttachment(accountId, emailId, attachmentId, mode="stash")`
+`get_email_attachment(accountId, emailId, attachmentId, mode="stash")`
 fetches an attachment from a received email. Two modes:
 
 ### `mode="stash"` (default)
@@ -69,7 +69,7 @@ Downloads the file into the server's attachment store and returns:
 ```
 
 The bytes never round-trip through the agent. Hand the returned
-`attachmentId` directly to `SendEmail` to forward, or (HTTP server
+`attachmentId` directly to `send_email` to forward, or (HTTP server
 only) fetch the raw bytes via `GET /attachments/{id}` for non-MCP
 consumers.
 
@@ -83,14 +83,14 @@ content (e.g., to OCR an image, parse a small PDF). Files larger than
 ## Forwarding flow (the most common pattern)
 
 ```
-GetEmailDetails(accountId, emailId)
+get_email_details(accountId, emailId)
   → response.attachments[]   // each has provider-side attachmentId
 
 For each attachment to forward:
-  GetEmailAttachment(accountId, emailId, attachmentId, mode="stash")
+  get_email_attachment(accountId, emailId, attachmentId, mode="stash")
   → response.attachmentId     // server-stash ID (different from provider's)
 
-SendEmail(
+send_email(
   to=[<forward target>],
   subject="...",
   body="...",
@@ -105,10 +105,10 @@ Two distinct `attachmentId` namespaces exist:
 
 | Source | What it identifies | Where it's used |
 |---|---|---|
-| `GetEmailDetails.attachments[].attachmentId` | Provider-side ID (Gmail `part-0`, Graph opaque ID) | Input to `GetEmailAttachment` |
-| `GetEmailAttachment` (stash) / `POST /attachments` | Server-side store ID | Input to `SendEmail` |
+| `get_email_details.attachments[].attachmentId` | Provider-side ID (Gmail `part-0`, Graph opaque ID) | Input to `get_email_attachment` |
+| `get_email_attachment` (stash) / `POST /attachments` | Server-side store ID | Input to `send_email` |
 
-Don't mix them — passing a provider-side ID directly to `SendEmail`
+Don't mix them — passing a provider-side ID directly to `send_email`
 fails.
 
 ## Size limits
@@ -117,7 +117,7 @@ fails.
 |---|---|---|
 | Total decoded payload per outbound message | 25 MB | This server |
 | Per-attachment cap | 3 MB (M365 / Outlook.com), 25 MB (Google) | Upstream provider |
-| Inline mode (`GetEmailAttachment mode="inline"`) | 1 MB | This server |
+| Inline mode (`get_email_attachment mode="inline"`) | 1 MB | This server |
 | Server store per-item | Configurable (admin) | This server |
 
 Exceeding the total or per-attachment caps results in `McpException`
@@ -126,7 +126,7 @@ with a descriptive message — surface it to the user; don't retry blindly.
 ## Pitfalls
 
 - **Stash IDs are single-use** for sending; consume them by passing to
-  `SendEmail`. Re-stash if needed.
+  `send_email`. Re-stash if needed.
 - **IDs expire** (server-configurable, default minutes-to-hours). Treat
   them as transient — get-and-use within the same conversation turn
   when possible.

--- a/src/CalendarMcp.Core/Skills/calendar.md
+++ b/src/CalendarMcp.Core/Skills/calendar.md
@@ -1,0 +1,142 @@
+# Calendar
+
+Calendar tools read, create, update, and respond to events across
+Microsoft 365, Google, Outlook.com, and read-only iCalendar/JSON
+sources.
+
+## Timezones are mandatory
+
+Every read and write tool that takes times requires a `timeZone`
+parameter as an IANA name (`America/Chicago`, `Europe/London`,
+`Asia/Tokyo`). Pass the user's local timezone. Times you send or
+receive without specifying a zone will be interpreted at server local
+time, which is rarely what you want.
+
+`GetCalendarEvents` returns each event in **both** UTC (`start_utc`,
+`end_utc`) and the requested local zone (`start_local`, `end_local`).
+Use the local times when surfacing to the user; use the UTC times when
+comparing or scheduling.
+
+## Tool reference
+
+### `ListCalendars(accountId?)`
+
+Returns `id, accountId, name, owner, canEdit, isDefault` per calendar.
+Fans out across all accounts when `accountId` is omitted. Use the
+returned `id` + `accountId` to scope `GetCalendarEvents` or
+`CreateEvent` to a specific calendar; otherwise the default calendar is
+used.
+
+### `GetCalendarEvents(timeZone, startDate?, endDate?, accountId?, calendarId?, count=50)`
+
+- `timeZone` (required) — IANA name; controls the `_local` times in
+  output and how `startDate`/`endDate` are interpreted.
+- `startDate` defaults to today (in `timeZone`); `endDate` defaults to
+  7 days after `startDate`.
+- `accountId` is required unless `calendarId` uniquely identifies one
+  account (the server resolves it).
+- `count` is per-account.
+
+Returns events sorted by start time, each with `id, accountId,
+calendarId, subject, start_utc/start_local, end_utc/end_local,
+location, attendees, isAllDay, organizer`.
+
+### `GetCalendarEventDetails(accountId, calendarId, eventId, timeZone)`
+
+Full event including description/body. All four parameters are required.
+
+### `CreateEvent(subject, start, end, accountId?, calendarId?, location?, attendees?[], body?, timeZone)`
+
+- `start` and `end` are ISO 8601 (e.g. `2026-05-14T10:00:00`).
+- Pair them with `timeZone` (IANA). Without `timeZone`, the times are
+  interpreted in server local time — usually wrong.
+- Omitting `accountId` uses the first configured account, which is
+  almost never what you want. Always pass `accountId` explicitly when
+  creating events.
+- Omitting `calendarId` uses the account's default calendar.
+- `attendees` is an array of email addresses.
+
+### `UpdateEvent(accountId, calendarId, eventId, subject?, start?, end?, location?, attendees?[], timeZone?)`
+
+All except identifiers are optional; pass only what you want to change.
+When updating `start` or `end`, also pass `timeZone`.
+
+### `DeleteEvent(accountId, calendarId, eventId)`
+
+Removes the event. Some providers send cancellation notices to
+attendees automatically.
+
+### `RespondToEvent(eventId, response, accountId?, calendarId?, comment?)`
+
+- `response`: `accept`, `tentative`, or `decline` (also accepts the
+  longer forms `accepted`, `tentativelyaccepted`, `declined`).
+- **Always pass `accountId`** — omitting it falls back to the first
+  configured account, which typically does not have the invitation.
+- `comment` is optional message text sent with the response.
+
+## Common patterns
+
+### Show my week
+
+```
+ListAccounts → pick calendar-capable account(s)
+GetCalendarEvents(
+  timeZone="America/Chicago",
+  startDate="2026-05-11",
+  endDate="2026-05-17",
+  accountId="work-m365"
+)
+→ display events using _local times
+```
+
+### Schedule a 30-minute meeting tomorrow at 10 AM
+
+```
+CreateEvent(
+  accountId="work-m365",
+  subject="Sync with Alice",
+  start="2026-05-13T10:00:00",
+  end="2026-05-13T10:30:00",
+  timeZone="America/Chicago",
+  attendees=["alice@example.com"],
+  body="Quick sync on the proposal."
+)
+```
+
+### Move a meeting
+
+```
+GetCalendarEvents(...)                              // find the event
+GetCalendarEventDetails(accountId, calendarId, eventId, timeZone)  // confirm details
+UpdateEvent(accountId, calendarId, eventId,
+            start="...", end="...", timeZone="...")
+```
+
+### Respond to an invite
+
+```
+GetCalendarEvents(...)                       // find pending invites
+RespondToEvent(eventId, "accept",
+               accountId="...", calendarId="...",
+               comment="Looking forward to it!")
+```
+
+### Find availability before scheduling
+
+There is no dedicated free-busy tool. Fetch your events for the target
+window with `GetCalendarEvents` and check for gaps manually. For
+multi-account availability, fan out and merge.
+
+## Pitfalls
+
+- **Default account** for `CreateEvent`/`RespondToEvent` is whichever
+  account was registered first — pass `accountId` explicitly.
+- **All-day events**: pass start/end as midnight-to-midnight in the
+  user's zone; check provider behavior — `isAllDay` is returned but
+  not a creation parameter.
+- **Recurring events**: not directly supported via tool parameters in
+  the current version. `GetCalendarEvents` returns expanded
+  occurrences; `CreateEvent` creates single instances.
+- **Read-only sources**: `ics` and `json` calendars cannot be written
+  to. `ListCalendars` reports `canEdit=false`. Verify before calling
+  `CreateEvent`/`UpdateEvent`/`DeleteEvent`.

--- a/src/CalendarMcp.Core/Skills/calendar.md
+++ b/src/CalendarMcp.Core/Skills/calendar.md
@@ -12,22 +12,22 @@ parameter as an IANA name (`America/Chicago`, `Europe/London`,
 receive without specifying a zone will be interpreted at server local
 time, which is rarely what you want.
 
-`GetCalendarEvents` returns each event in **both** UTC (`start_utc`,
+`get_calendar_events` returns each event in **both** UTC (`start_utc`,
 `end_utc`) and the requested local zone (`start_local`, `end_local`).
 Use the local times when surfacing to the user; use the UTC times when
 comparing or scheduling.
 
 ## Tool reference
 
-### `ListCalendars(accountId?)`
+### `list_calendars(accountId?)`
 
 Returns `id, accountId, name, owner, canEdit, isDefault` per calendar.
 Fans out across all accounts when `accountId` is omitted. Use the
-returned `id` + `accountId` to scope `GetCalendarEvents` or
-`CreateEvent` to a specific calendar; otherwise the default calendar is
+returned `id` + `accountId` to scope `get_calendar_events` or
+`create_event` to a specific calendar; otherwise the default calendar is
 used.
 
-### `GetCalendarEvents(timeZone, startDate?, endDate?, accountId?, calendarId?, count=50)`
+### `get_calendar_events(timeZone, startDate?, endDate?, accountId?, calendarId?, count=50)`
 
 - `timeZone` (required) — IANA name; controls the `_local` times in
   output and how `startDate`/`endDate` are interpreted.
@@ -41,11 +41,11 @@ Returns events sorted by start time, each with `id, accountId,
 calendarId, subject, start_utc/start_local, end_utc/end_local,
 location, attendees, isAllDay, organizer`.
 
-### `GetCalendarEventDetails(accountId, calendarId, eventId, timeZone)`
+### `get_calendar_event_details(accountId, calendarId, eventId, timeZone)`
 
 Full event including description/body. All four parameters are required.
 
-### `CreateEvent(subject, start, end, accountId?, calendarId?, location?, attendees?[], body?, timeZone)`
+### `create_event(subject, start, end, accountId?, calendarId?, location?, attendees?[], body?, timeZone)`
 
 - `start` and `end` are ISO 8601 (e.g. `2026-05-14T10:00:00`).
 - Pair them with `timeZone` (IANA). Without `timeZone`, the times are
@@ -56,17 +56,17 @@ Full event including description/body. All four parameters are required.
 - Omitting `calendarId` uses the account's default calendar.
 - `attendees` is an array of email addresses.
 
-### `UpdateEvent(accountId, calendarId, eventId, subject?, start?, end?, location?, attendees?[], timeZone?)`
+### `update_event(accountId, calendarId, eventId, subject?, start?, end?, location?, attendees?[], timeZone?)`
 
 All except identifiers are optional; pass only what you want to change.
 When updating `start` or `end`, also pass `timeZone`.
 
-### `DeleteEvent(accountId, calendarId, eventId)`
+### `delete_event(accountId, calendarId, eventId)`
 
 Removes the event. Some providers send cancellation notices to
 attendees automatically.
 
-### `RespondToEvent(eventId, response, accountId?, calendarId?, comment?)`
+### `respond_to_event(eventId, response, accountId?, calendarId?, comment?)`
 
 - `response`: `accept`, `tentative`, or `decline` (also accepts the
   longer forms `accepted`, `tentativelyaccepted`, `declined`).
@@ -79,8 +79,8 @@ attendees automatically.
 ### Show my week
 
 ```
-ListAccounts → pick calendar-capable account(s)
-GetCalendarEvents(
+list_accounts → pick calendar-capable account(s)
+get_calendar_events(
   timeZone="America/Chicago",
   startDate="2026-05-11",
   endDate="2026-05-17",
@@ -92,7 +92,7 @@ GetCalendarEvents(
 ### Schedule a 30-minute meeting tomorrow at 10 AM
 
 ```
-CreateEvent(
+create_event(
   accountId="work-m365",
   subject="Sync with Alice",
   start="2026-05-13T10:00:00",
@@ -106,17 +106,17 @@ CreateEvent(
 ### Move a meeting
 
 ```
-GetCalendarEvents(...)                              // find the event
-GetCalendarEventDetails(accountId, calendarId, eventId, timeZone)  // confirm details
-UpdateEvent(accountId, calendarId, eventId,
+get_calendar_events(...)                              // find the event
+get_calendar_event_details(accountId, calendarId, eventId, timeZone)  // confirm details
+update_event(accountId, calendarId, eventId,
             start="...", end="...", timeZone="...")
 ```
 
 ### Respond to an invite
 
 ```
-GetCalendarEvents(...)                       // find pending invites
-RespondToEvent(eventId, "accept",
+get_calendar_events(...)                       // find pending invites
+respond_to_event(eventId, "accept",
                accountId="...", calendarId="...",
                comment="Looking forward to it!")
 ```
@@ -124,19 +124,19 @@ RespondToEvent(eventId, "accept",
 ### Find availability before scheduling
 
 There is no dedicated free-busy tool. Fetch your events for the target
-window with `GetCalendarEvents` and check for gaps manually. For
+window with `get_calendar_events` and check for gaps manually. For
 multi-account availability, fan out and merge.
 
 ## Pitfalls
 
-- **Default account** for `CreateEvent`/`RespondToEvent` is whichever
+- **Default account** for `create_event`/`respond_to_event` is whichever
   account was registered first — pass `accountId` explicitly.
 - **All-day events**: pass start/end as midnight-to-midnight in the
   user's zone; check provider behavior — `isAllDay` is returned but
   not a creation parameter.
 - **Recurring events**: not directly supported via tool parameters in
-  the current version. `GetCalendarEvents` returns expanded
-  occurrences; `CreateEvent` creates single instances.
+  the current version. `get_calendar_events` returns expanded
+  occurrences; `create_event` creates single instances.
 - **Read-only sources**: `ics` and `json` calendars cannot be written
-  to. `ListCalendars` reports `canEdit=false`. Verify before calling
-  `CreateEvent`/`UpdateEvent`/`DeleteEvent`.
+  to. `list_calendars` reports `canEdit=false`. Verify before calling
+  `create_event`/`update_event`/`delete_event`.

--- a/src/CalendarMcp.Core/Skills/contacts.md
+++ b/src/CalendarMcp.Core/Skills/contacts.md
@@ -4,27 +4,27 @@ Contact tools are available on Microsoft 365, Google (People API),
 Outlook.com, and optionally JSON-file accounts. IMAP and ICS accounts
 do not expose contacts.
 
-Always confirm capability via `ListAccounts` before calling a contact
+Always confirm capability via `list_accounts` before calling a contact
 tool against an account.
 
 ## Tool reference
 
-### `GetContacts(accountId?, count=50)`
+### `get_contacts(accountId?, count=50)`
 
 Lists contacts. Fans out across contact-capable accounts when
 `accountId` is omitted. Returns lightweight metadata.
 
-### `SearchContacts(query, accountId?, count=20)`
+### `search_contacts(query, accountId?, count=20)`
 
 Full-text search across name, email, company. Fans out across all
 contact-capable accounts when `accountId` is omitted.
 
-### `GetContactDetails(accountId, contactId)`
+### `get_contact_details(accountId, contactId)`
 
 Returns the full contact record including all email addresses, phone
 numbers, addresses, and notes.
 
-### `CreateContact(displayName, accountId?, givenName?, surname?, email?, phone?, jobTitle?, companyName?, notes?)`
+### `create_contact(displayName, accountId?, givenName?, surname?, email?, phone?, jobTitle?, companyName?, notes?)`
 
 - `displayName` is required.
 - `email` and `phone` accept a single value or a comma-separated list.
@@ -32,12 +32,12 @@ numbers, addresses, and notes.
   smart routing — pass it explicitly if you care which account ends up
   with the contact.
 
-### `UpdateContact(accountId, contactId, ...)`
+### `update_contact(accountId, contactId, ...)`
 
-Same shape as `CreateContact` but with `contactId` and all other fields
+Same shape as `create_contact` but with `contactId` and all other fields
 optional. Pass only what changes.
 
-### `DeleteContact(accountId, contactId)`
+### `delete_contact(accountId, contactId)`
 
 Permanent on most providers; no per-tool soft-delete or recovery.
 
@@ -46,18 +46,18 @@ Permanent on most providers; no per-tool soft-delete or recovery.
 ### Find a contact by name or company
 
 ```
-SearchContacts(query="Acme")    // fans out across accounts
+search_contacts(query="Acme")    // fans out across accounts
 → examine results, pick the right one
-→ GetContactDetails(accountId, contactId) for full info
+→ get_contact_details(accountId, contactId) for full info
 ```
 
 ### Promote an email sender to a contact
 
 ```
-GetEmailDetails(accountId, emailId)    // get from, fromName
-SearchContacts(query=fromEmail)        // check for an existing record
+get_email_details(accountId, emailId)    // get from, fromName
+search_contacts(query=fromEmail)        // check for an existing record
 → if no match:
-   CreateContact(
+   create_contact(
      accountId=<contact-capable account>,
      displayName=fromName,
      email=fromEmail
@@ -70,7 +70,7 @@ user.
 
 ### Bulk import
 
-There is no bulk-create tool. Call `CreateContact` once per record;
+There is no bulk-create tool. Call `create_contact` once per record;
 use the per-call response to detect duplicates.
 
 ## Pitfalls

--- a/src/CalendarMcp.Core/Skills/contacts.md
+++ b/src/CalendarMcp.Core/Skills/contacts.md
@@ -1,0 +1,85 @@
+# Contacts
+
+Contact tools are available on Microsoft 365, Google (People API),
+Outlook.com, and optionally JSON-file accounts. IMAP and ICS accounts
+do not expose contacts.
+
+Always confirm capability via `ListAccounts` before calling a contact
+tool against an account.
+
+## Tool reference
+
+### `GetContacts(accountId?, count=50)`
+
+Lists contacts. Fans out across contact-capable accounts when
+`accountId` is omitted. Returns lightweight metadata.
+
+### `SearchContacts(query, accountId?, count=20)`
+
+Full-text search across name, email, company. Fans out across all
+contact-capable accounts when `accountId` is omitted.
+
+### `GetContactDetails(accountId, contactId)`
+
+Returns the full contact record including all email addresses, phone
+numbers, addresses, and notes.
+
+### `CreateContact(displayName, accountId?, givenName?, surname?, email?, phone?, jobTitle?, companyName?, notes?)`
+
+- `displayName` is required.
+- `email` and `phone` accept a single value or a comma-separated list.
+- Omitting `accountId` falls back to "first configured account" or
+  smart routing — pass it explicitly if you care which account ends up
+  with the contact.
+
+### `UpdateContact(accountId, contactId, ...)`
+
+Same shape as `CreateContact` but with `contactId` and all other fields
+optional. Pass only what changes.
+
+### `DeleteContact(accountId, contactId)`
+
+Permanent on most providers; no per-tool soft-delete or recovery.
+
+## Common patterns
+
+### Find a contact by name or company
+
+```
+SearchContacts(query="Acme")    // fans out across accounts
+→ examine results, pick the right one
+→ GetContactDetails(accountId, contactId) for full info
+```
+
+### Promote an email sender to a contact
+
+```
+GetEmailDetails(accountId, emailId)    // get from, fromName
+SearchContacts(query=fromEmail)        // check for an existing record
+→ if no match:
+   CreateContact(
+     accountId=<contact-capable account>,
+     displayName=fromName,
+     email=fromEmail
+   )
+```
+
+When picking which account to store the new contact in, prefer the
+same account that received the email (consistent persona), or ask the
+user.
+
+### Bulk import
+
+There is no bulk-create tool. Call `CreateContact` once per record;
+use the per-call response to detect duplicates.
+
+## Pitfalls
+
+- **Provider quirks**: Google's People API normalizes phone numbers
+  and email types differently than Graph; round-tripping a contact
+  between providers can change formatting.
+- **`displayName` only**: when only `displayName` is provided, some
+  providers (Google) parse it into given/family name heuristically.
+  Pass `givenName`/`surname` explicitly when you have them.
+- **Duplicate detection** is your responsibility — providers don't
+  reject duplicates on create.

--- a/src/CalendarMcp.Core/Skills/email.md
+++ b/src/CalendarMcp.Core/Skills/email.md
@@ -1,0 +1,146 @@
+# Email
+
+Calendar MCP exposes email tools that work uniformly across Microsoft
+365, Google, Outlook.com, IMAP/SMTP, and (read-only) JSON-file accounts.
+
+## Two-stage retrieval
+
+Every list/search tool returns lightweight metadata only — never the
+body. Fetching a body is a deliberate second step. This keeps token
+usage proportional to attention.
+
+```
+GetEmails / SearchEmails   →  [{ id, accountId, subject, from, ... }]
+                                       │
+                                       ▼
+                       GetEmailDetails(accountId, emailId)
+                                       │
+                                       ▼
+                       { subject, from, to, cc, body, attachments, ... }
+```
+
+The `id` returned by list tools is the parameter for `GetEmailDetails`
+and is passed as `emailId` (**not** `messageId`). The `accountId` field
+must come along — both are required.
+
+## Tool reference
+
+### `GetEmails(accountId?, count=20, unreadOnly=false)`
+
+Recent emails, newest first. Omit `accountId` to fan out across all
+accounts. Returns `id, accountId, subject, from, receivedDateTime, isRead, hasAttachments`.
+
+### `SearchEmails(query, accountId?, count=20, fromDate?, toDate?)`
+
+Full-text search across subject and body. Date filters are ISO-8601
+(`2026-02-01`). Fans out across all accounts when `accountId` is
+omitted. Same return shape as `GetEmails`.
+
+### `GetEmailDetails(accountId, emailId)`
+
+Returns full body, recipients, and the `attachments[]` array. Each
+attachment has `attachmentId` — feed that to `GetEmailAttachment`.
+
+### `SendEmail(to[], subject, body, accountId?, bodyFormat="html", cc?[], attachments?[])`
+
+- `to` is an array of strings. Single recipient: `["alice@x"]`.
+- `bodyFormat` defaults to `"html"`. Set `"text"` for plain.
+- `accountId` is *optional but you should usually pass it.* When omitted,
+  smart routing picks based on first recipient's domain (see `accounts`).
+- `attachments`: see `attachments` guide. Pass either `{attachmentId: "..."}`
+  (from the upload endpoint or `GetEmailAttachment` stash mode) or
+  `{name: "...", base64Content: "..."}` for very small files.
+
+### `DeleteEmail(accountId, emailId)`
+
+Moves to Trash/Bin on most providers (recoverable for some retention
+window). Treat as not-recoverable when planning user-visible actions.
+
+### `MarkEmailAsRead(accountId, emailId, isRead=true)`
+
+Pass `isRead=false` to mark unread.
+
+### `MoveEmail(accountId, emailId, destination)`
+
+`destination` values: `archive`, `inbox`, `trash`, `spam`, `drafts`
+(Microsoft only), `sentitems` (Microsoft only), or a custom folder/label
+ID (Google labels are addressed by ID). Aliases: `deleteditems`→`trash`,
+`junkemail`→`spam`.
+
+### Bulk operations
+
+`BulkDeleteEmails(items[])`, `BulkMarkEmailsAsRead(items[])`,
+`BulkMoveEmailsTool(items[], destination)` all take an array of
+`{accountId, emailId}` items (max 50). Each item succeeds or fails
+independently; the response contains per-item `success`/`error`.
+**Use these for any operation touching more than 3 emails** —
+materially faster than serial calls and rate-limit friendly.
+
+### `GetUnsubscribeInfo(accountId, emailId)`
+
+Inspects `List-Unsubscribe` / `List-Unsubscribe-Post` headers
+(RFC 2369/8058) on the email. Returns which methods are available
+(`oneClick`, `https`, `mailto`) without taking any action.
+
+### `UnsubscribeFromEmail(accountId, emailId, method="auto")`
+
+Executes the unsubscribe. With `method="auto"` (the default), tries
+one-click POST first, then falls back to returning the HTTPS URL, then
+to sending a mailto-style unsubscribe message. Use a specific `method`
+when you have already inspected the email and decided how to proceed.
+
+### `get_contextual_email_summary(topics?, countPerAccount=50, unreadOnly=false, includeBodyPreview=false, maxSamplesPerCluster=5)`
+
+Heavyweight: fans out across all accounts, clusters by topic
+(meetings, financial, action-required, support, etc.), detects emails
+that may have been sent to the wrong account ("mismatches"), and
+profiles each account's "persona" (top sender domains, primary
+topics). Use for daily/weekly triage, not for routine lookups.
+
+## Common patterns
+
+### Triage unread
+
+```
+GetEmails(unreadOnly=true, count=50)   // fans out across all accounts
+→ for each:
+     ListAccounts result tells you the account's persona
+     decide: keep / archive / delete / unsubscribe
+→ BulkMoveEmails or BulkDeleteEmails to apply
+```
+
+### Find then read
+
+```
+SearchEmails(query="invoice december")
+→ pick the right hit
+→ GetEmailDetails(accountId, emailId)
+```
+
+### Reply with the same account that received
+
+When replying, always pass the original message's `accountId` to
+`SendEmail` so the reply goes from the right persona. Smart routing
+will sometimes pick correctly via the recipient domain, but not
+always — be explicit.
+
+### Bulk unsubscribe newsletters
+
+```
+SearchEmails(query="unsubscribe", count=50)
+→ for each candidate sender, optionally GetUnsubscribeInfo to verify
+→ UnsubscribeFromEmail(accountId, emailId, method="auto")
+→ BulkDeleteEmails(...) to remove the historical clutter
+```
+
+## Pitfalls
+
+- **`messageId` vs `emailId`**: the parameter name is `emailId`. The
+  field in returned objects is `id`. Don't pass `messageId`.
+- **HTML wrapping**: do not wrap `body` in `<![CDATA[...]]>`. The server
+  strips it defensively, but cleaner to not include it.
+- **Inline images in `body`**: not supported via tool input; send as
+  attachments and reference by `cid:` in HTML if needed (provider
+  dependent; not all providers support this through these tools).
+- **Threading**: there is no thread-aware tool. To handle a reply
+  thread, you operate on individual messages.

--- a/src/CalendarMcp.Core/Skills/email.md
+++ b/src/CalendarMcp.Core/Skills/email.md
@@ -10,57 +10,57 @@ body. Fetching a body is a deliberate second step. This keeps token
 usage proportional to attention.
 
 ```
-GetEmails / SearchEmails   →  [{ id, accountId, subject, from, ... }]
+get_emails / search_emails   →  [{ id, accountId, subject, from, ... }]
                                        │
                                        ▼
-                       GetEmailDetails(accountId, emailId)
+                       get_email_details(accountId, emailId)
                                        │
                                        ▼
                        { subject, from, to, cc, body, attachments, ... }
 ```
 
-The `id` returned by list tools is the parameter for `GetEmailDetails`
+The `id` returned by list tools is the parameter for `get_email_details`
 and is passed as `emailId` (**not** `messageId`). The `accountId` field
 must come along — both are required.
 
 ## Tool reference
 
-### `GetEmails(accountId?, count=20, unreadOnly=false)`
+### `get_emails(accountId?, count=20, unreadOnly=false)`
 
 Recent emails, newest first. Omit `accountId` to fan out across all
 accounts. Returns `id, accountId, subject, from, receivedDateTime, isRead, hasAttachments`.
 
-### `SearchEmails(query, accountId?, count=20, fromDate?, toDate?)`
+### `search_emails(query, accountId?, count=20, fromDate?, toDate?)`
 
 Full-text search across subject and body. Date filters are ISO-8601
 (`2026-02-01`). Fans out across all accounts when `accountId` is
-omitted. Same return shape as `GetEmails`.
+omitted. Same return shape as `get_emails`.
 
-### `GetEmailDetails(accountId, emailId)`
+### `get_email_details(accountId, emailId)`
 
 Returns full body, recipients, and the `attachments[]` array. Each
-attachment has `attachmentId` — feed that to `GetEmailAttachment`.
+attachment has `attachmentId` — feed that to `get_email_attachment`.
 
-### `SendEmail(to[], subject, body, accountId?, bodyFormat="html", cc?[], attachments?[])`
+### `send_email(to[], subject, body, accountId?, bodyFormat="html", cc?[], attachments?[])`
 
 - `to` is an array of strings. Single recipient: `["alice@x"]`.
 - `bodyFormat` defaults to `"html"`. Set `"text"` for plain.
 - `accountId` is *optional but you should usually pass it.* When omitted,
   smart routing picks based on first recipient's domain (see `accounts`).
 - `attachments`: see `attachments` guide. Pass either `{attachmentId: "..."}`
-  (from the upload endpoint or `GetEmailAttachment` stash mode) or
+  (from the upload endpoint or `get_email_attachment` stash mode) or
   `{name: "...", base64Content: "..."}` for very small files.
 
-### `DeleteEmail(accountId, emailId)`
+### `delete_email(accountId, emailId)`
 
 Moves to Trash/Bin on most providers (recoverable for some retention
 window). Treat as not-recoverable when planning user-visible actions.
 
-### `MarkEmailAsRead(accountId, emailId, isRead=true)`
+### `mark_email_as_read(accountId, emailId, isRead=true)`
 
 Pass `isRead=false` to mark unread.
 
-### `MoveEmail(accountId, emailId, destination)`
+### `move_email(accountId, emailId, destination)`
 
 `destination` values: `archive`, `inbox`, `trash`, `spam`, `drafts`
 (Microsoft only), `sentitems` (Microsoft only), or a custom folder/label
@@ -69,20 +69,20 @@ ID (Google labels are addressed by ID). Aliases: `deleteditems`→`trash`,
 
 ### Bulk operations
 
-`BulkDeleteEmails(items[])`, `BulkMarkEmailsAsRead(items[])`,
-`BulkMoveEmailsTool(items[], destination)` all take an array of
+`bulk_delete_emails(items[])`, `bulk_mark_emails_as_read(items[])`,
+`bulk_move_emails(items[], destination)` all take an array of
 `{accountId, emailId}` items (max 50). Each item succeeds or fails
 independently; the response contains per-item `success`/`error`.
 **Use these for any operation touching more than 3 emails** —
 materially faster than serial calls and rate-limit friendly.
 
-### `GetUnsubscribeInfo(accountId, emailId)`
+### `get_unsubscribe_info(accountId, emailId)`
 
 Inspects `List-Unsubscribe` / `List-Unsubscribe-Post` headers
 (RFC 2369/8058) on the email. Returns which methods are available
 (`oneClick`, `https`, `mailto`) without taking any action.
 
-### `UnsubscribeFromEmail(accountId, emailId, method="auto")`
+### `unsubscribe_from_email(accountId, emailId, method="auto")`
 
 Executes the unsubscribe. With `method="auto"` (the default), tries
 one-click POST first, then falls back to returning the HTTPS URL, then
@@ -102,35 +102,35 @@ topics). Use for daily/weekly triage, not for routine lookups.
 ### Triage unread
 
 ```
-GetEmails(unreadOnly=true, count=50)   // fans out across all accounts
+get_emails(unreadOnly=true, count=50)   // fans out across all accounts
 → for each:
-     ListAccounts result tells you the account's persona
+     list_accounts result tells you the account's persona
      decide: keep / archive / delete / unsubscribe
-→ BulkMoveEmails or BulkDeleteEmails to apply
+→ bulk_move_emails or bulk_delete_emails to apply
 ```
 
 ### Find then read
 
 ```
-SearchEmails(query="invoice december")
+search_emails(query="invoice december")
 → pick the right hit
-→ GetEmailDetails(accountId, emailId)
+→ get_email_details(accountId, emailId)
 ```
 
 ### Reply with the same account that received
 
 When replying, always pass the original message's `accountId` to
-`SendEmail` so the reply goes from the right persona. Smart routing
+`send_email` so the reply goes from the right persona. Smart routing
 will sometimes pick correctly via the recipient domain, but not
 always — be explicit.
 
 ### Bulk unsubscribe newsletters
 
 ```
-SearchEmails(query="unsubscribe", count=50)
-→ for each candidate sender, optionally GetUnsubscribeInfo to verify
-→ UnsubscribeFromEmail(accountId, emailId, method="auto")
-→ BulkDeleteEmails(...) to remove the historical clutter
+search_emails(query="unsubscribe", count=50)
+→ for each candidate sender, optionally get_unsubscribe_info to verify
+→ unsubscribe_from_email(accountId, emailId, method="auto")
+→ bulk_delete_emails(...) to remove the historical clutter
 ```
 
 ## Pitfalls

--- a/src/CalendarMcp.Core/Skills/overview.md
+++ b/src/CalendarMcp.Core/Skills/overview.md
@@ -6,7 +6,7 @@ every configured account; capabilities vary per provider.
 
 ## Always start here
 
-1. Call **`ListAccounts`** to discover what accounts are configured and what
+1. Call **`list_accounts`** to discover what accounts are configured and what
    each can do. The response includes an `accountId`, `provider`,
    `displayName`, `domains`, and a `capabilities` array per account.
 2. Pass the chosen `accountId` to every tool that operates on data (email,
@@ -31,24 +31,23 @@ account configuration.
 
 ## Tool categories
 
-- **Accounts / meta**: `ListAccounts`, `GetGuide`
-- **Email read**: `GetEmails`, `SearchEmails`, `GetEmailDetails`,
-  `GetEmailAttachment`, `get_contextual_email_summary`
-- **Email write**: `SendEmail`, `DeleteEmail`, `MarkEmailAsRead`,
-  `MoveEmail`
-- **Email bulk**: `BulkDeleteEmails`, `BulkMarkEmailsAsRead`,
-  `BulkMoveEmails`
-- **Email unsubscribe**: `GetUnsubscribeInfo`, `UnsubscribeFromEmail`
-- **Calendar read**: `ListCalendars`, `GetCalendarEvents`,
-  `GetCalendarEventDetails`
-- **Calendar write**: `CreateEvent`, `UpdateEvent`, `DeleteEvent`,
-  `RespondToEvent`
-- **Contacts**: `GetContacts`, `SearchContacts`, `GetContactDetails`,
-  `CreateContact`, `UpdateContact`, `DeleteContact`
+- **Accounts / meta**: `list_accounts`, `get_guide`
+- **Email read**: `get_emails`, `search_emails`, `get_email_details`,
+  `get_email_attachment`, `get_contextual_email_summary`
+- **Email write**: `send_email`, `delete_email`, `mark_email_as_read`,
+  `move_email`
+- **Email bulk**: `bulk_delete_emails`, `bulk_mark_emails_as_read`,
+  `bulk_move_emails`
+- **Email unsubscribe**: `get_unsubscribe_info`, `unsubscribe_from_email`
+- **Calendar read**: `list_calendars`, `get_calendar_events`,
+  `get_calendar_event_details`
+- **Calendar write**: `create_event`, `update_event`, `delete_event`,
+  `respond_to_event`
+- **Contacts**: `get_contacts`, `search_contacts`, `get_contact_details`,
+  `create_contact`, `update_contact`, `delete_contact`
 
-Tool names are PascalCase as exposed by the C# MCP SDK. The only
-exception is `get_contextual_email_summary`, which is published as
-snake_case for historical reasons.
+Tool names are snake_case (the C# MCP SDK auto-converts from the
+PascalCase method names in the source).
 
 ## Where to go next
 

--- a/src/CalendarMcp.Core/Skills/overview.md
+++ b/src/CalendarMcp.Core/Skills/overview.md
@@ -1,0 +1,62 @@
+# Calendar MCP — Overview
+
+Calendar MCP gives a single MCP interface to email, calendar, and contacts
+across multiple personal-information providers. The same tools work against
+every configured account; capabilities vary per provider.
+
+## Always start here
+
+1. Call **`ListAccounts`** to discover what accounts are configured and what
+   each can do. The response includes an `accountId`, `provider`,
+   `displayName`, `domains`, and a `capabilities` array per account.
+2. Pass the chosen `accountId` to every tool that operates on data (email,
+   calendar, contacts). Tools that accept a missing `accountId` will fall
+   back to "first configured account" or "smart routing by recipient
+   domain" — both can silently target the wrong account, so prefer being
+   explicit.
+
+## Provider capability matrix
+
+| Provider | Email | Calendar | Contacts | Notes |
+|---|---|---|---|---|
+| Microsoft 365 (`microsoft365`) | RW | RW | RW | Graph API; per-attachment cap 3 MB |
+| Outlook.com (`outlook.com`) | RW | RW | RW | Same Graph cap as M365 |
+| Google Workspace / Gmail (`google`) | RW | RW | RW | People API for contacts; uses labels rather than folders |
+| IMAP + SMTP (`imap`) | RW | — | — | For unattended mailboxes lacking OAuth |
+| iCalendar URL (`ics`) | — | R | — | Subscribed `.ics` feeds; read-only |
+| JSON file (`json`) | R* | R | R* | Local/OneDrive JSON; email + contacts optional |
+
+`RW` = read/write, `R` = read-only, `R*` = read-only and optional per
+account configuration.
+
+## Tool categories
+
+- **Accounts / meta**: `ListAccounts`, `GetGuide`
+- **Email read**: `GetEmails`, `SearchEmails`, `GetEmailDetails`,
+  `GetEmailAttachment`, `get_contextual_email_summary`
+- **Email write**: `SendEmail`, `DeleteEmail`, `MarkEmailAsRead`,
+  `MoveEmail`
+- **Email bulk**: `BulkDeleteEmails`, `BulkMarkEmailsAsRead`,
+  `BulkMoveEmails`
+- **Email unsubscribe**: `GetUnsubscribeInfo`, `UnsubscribeFromEmail`
+- **Calendar read**: `ListCalendars`, `GetCalendarEvents`,
+  `GetCalendarEventDetails`
+- **Calendar write**: `CreateEvent`, `UpdateEvent`, `DeleteEvent`,
+  `RespondToEvent`
+- **Contacts**: `GetContacts`, `SearchContacts`, `GetContactDetails`,
+  `CreateContact`, `UpdateContact`, `DeleteContact`
+
+Tool names are PascalCase as exposed by the C# MCP SDK. The only
+exception is `get_contextual_email_summary`, which is published as
+snake_case for historical reasons.
+
+## Where to go next
+
+- `accounts` — multi-account routing, capabilities, domain matching
+- `email` — full email workflow with examples
+- `calendar` — calendar workflow (note: `timeZone` is mandatory on most
+  calendar tools)
+- `contacts` — contact CRUD
+- `attachments` — the non-obvious stash/upload/forward flow
+- `scenarios` — end-to-end multi-tool workflows
+- `providers` — per-provider behavior and quirks

--- a/src/CalendarMcp.Core/Skills/providers.md
+++ b/src/CalendarMcp.Core/Skills/providers.md
@@ -1,7 +1,7 @@
 # Providers
 
 Per-provider behavior, quirks, and capability nuances. The `provider`
-field returned by `ListAccounts` selects which of these applies to a
+field returned by `list_accounts` selects which of these applies to a
 given account.
 
 ## Microsoft 365 (`microsoft365`)
@@ -10,14 +10,14 @@ given account.
   silently on the server).
 - **Capabilities**: email, calendar, contacts — all read/write.
 - **API**: Microsoft Graph.
-- **Folders**: real folder structure. `MoveEmail` destinations accept
+- **Folders**: real folder structure. `move_email` destinations accept
   `inbox`, `archive`, `trash` (alias `deleteditems`), `spam` (alias
   `junkemail`), `drafts`, `sentitems`, or a folder ID.
 - **Attachments**: per-attachment cap **3 MB** (Graph limit). For
   bigger files, Graph supports an upload-session protocol that this
   server does not currently use — large attachments will fail.
 - **Recurring events**: returned as expanded occurrences in
-  `GetCalendarEvents`; not directly creatable through this server.
+  `get_calendar_events`; not directly creatable through this server.
 - **Default calendar** = the user's primary calendar in Outlook.
 
 ## Outlook.com / Hotmail (`outlook.com`)
@@ -33,14 +33,14 @@ given account.
 - **Auth**: Google OAuth.
 - **Capabilities**: email, calendar, contacts — all read/write.
 - **APIs**: Gmail API, Calendar API, People API.
-- **Folders → labels**: Gmail has no folders. `MoveEmail` destinations:
+- **Folders → labels**: Gmail has no folders. `move_email` destinations:
   - `inbox`, `trash`, `spam`, `archive` (archive = remove `INBOX` label)
   - Any other value is treated as a label ID (not a label *name*) — get
     label IDs from the Gmail label list (not currently exposed as a
     tool; ask the admin or check the email headers).
 - **Threads vs messages**: Gmail's natural unit is the thread. These
   tools operate on individual messages — the `id` you pass to
-  `GetEmailDetails` is a message ID, not a thread ID.
+  `get_email_details` is a message ID, not a thread ID.
 - **Attachment IDs**: typically `part-<n>` (e.g. `part-0`, `part-1`).
 - **Attachments**: 25 MB upper limit on the Gmail side.
 - **Contacts**: People API; phone/email types may be normalized
@@ -68,9 +68,9 @@ given account.
 - **Capabilities**: calendar — **read-only**.
 - **Use case**: subscribed feeds (sports schedules, school calendars,
   shared family calendars exported as `.ics`).
-- **`ListCalendars`**: returns a single calendar with `canEdit=false`.
-- **Write tools** (`CreateEvent`, `UpdateEvent`, `DeleteEvent`,
-  `RespondToEvent`) **will fail** — check `capabilities[].readOnly` first.
+- **`list_calendars`**: returns a single calendar with `canEdit=false`.
+- **Write tools** (`create_event`, `update_event`, `delete_event`,
+  `respond_to_event`) **will fail** — check `capabilities[].readOnly` first.
 - **Refresh**: the server polls the URL; events reflect the last
   successful fetch, which can lag.
 

--- a/src/CalendarMcp.Core/Skills/providers.md
+++ b/src/CalendarMcp.Core/Skills/providers.md
@@ -1,0 +1,101 @@
+# Providers
+
+Per-provider behavior, quirks, and capability nuances. The `provider`
+field returned by `ListAccounts` selects which of these applies to a
+given account.
+
+## Microsoft 365 (`microsoft365`)
+
+- **Auth**: Entra ID OAuth via MSAL (interactive once, then refreshed
+  silently on the server).
+- **Capabilities**: email, calendar, contacts — all read/write.
+- **API**: Microsoft Graph.
+- **Folders**: real folder structure. `MoveEmail` destinations accept
+  `inbox`, `archive`, `trash` (alias `deleteditems`), `spam` (alias
+  `junkemail`), `drafts`, `sentitems`, or a folder ID.
+- **Attachments**: per-attachment cap **3 MB** (Graph limit). For
+  bigger files, Graph supports an upload-session protocol that this
+  server does not currently use — large attachments will fail.
+- **Recurring events**: returned as expanded occurrences in
+  `GetCalendarEvents`; not directly creatable through this server.
+- **Default calendar** = the user's primary calendar in Outlook.
+
+## Outlook.com / Hotmail (`outlook.com`)
+
+- **Auth**: same Graph endpoint as M365 but consumer-account flow.
+- **Capabilities**: same as M365.
+- **Quirks**: same 3 MB attachment cap; Outlook.com aliases sometimes
+  appear in `from` as the underlying Microsoft account rather than the
+  alias used to send — this is a Graph quirk, not a bug here.
+
+## Google Workspace / Gmail (`google`)
+
+- **Auth**: Google OAuth.
+- **Capabilities**: email, calendar, contacts — all read/write.
+- **APIs**: Gmail API, Calendar API, People API.
+- **Folders → labels**: Gmail has no folders. `MoveEmail` destinations:
+  - `inbox`, `trash`, `spam`, `archive` (archive = remove `INBOX` label)
+  - Any other value is treated as a label ID (not a label *name*) — get
+    label IDs from the Gmail label list (not currently exposed as a
+    tool; ask the admin or check the email headers).
+- **Threads vs messages**: Gmail's natural unit is the thread. These
+  tools operate on individual messages — the `id` you pass to
+  `GetEmailDetails` is a message ID, not a thread ID.
+- **Attachment IDs**: typically `part-<n>` (e.g. `part-0`, `part-1`).
+- **Attachments**: 25 MB upper limit on the Gmail side.
+- **Contacts**: People API; phone/email types may be normalized
+  differently than Graph.
+
+## IMAP + SMTP (`imap`)
+
+- **Auth**: username + password (or app password). Stored encrypted at
+  rest via the server's data-protection key.
+- **Capabilities**: email only — no calendar, no contacts.
+- **Use case**: unattended mailboxes lacking OAuth, role-based accounts,
+  legacy systems.
+- **Folders**: IMAP folder names are mailbox-specific. The destination
+  aliases (`archive`, `trash`, `spam`, `inbox`) are mapped to common
+  conventions (`Archive`, `INBOX`, `[Gmail]/Spam`, etc.) but custom
+  folders may need their literal name as `destination`.
+- **Search**: IMAP SEARCH is less powerful than Graph/Gmail; complex
+  queries may not match. Falls back to client-side filtering when needed.
+- **Unsubscribe**: `List-Unsubscribe` headers are parsed the same way
+  as Graph/Gmail, so unsubscribe flows work.
+
+## iCalendar URL (`ics`)
+
+- **Auth**: none (public URL) or basic-auth (configurable).
+- **Capabilities**: calendar — **read-only**.
+- **Use case**: subscribed feeds (sports schedules, school calendars,
+  shared family calendars exported as `.ics`).
+- **`ListCalendars`**: returns a single calendar with `canEdit=false`.
+- **Write tools** (`CreateEvent`, `UpdateEvent`, `DeleteEvent`,
+  `RespondToEvent`) **will fail** — check `capabilities[].readOnly` first.
+- **Refresh**: the server polls the URL; events reflect the last
+  successful fetch, which can lag.
+
+## JSON file (`json`)
+
+- **Auth**: file-system access (local file or OneDrive path).
+- **Capabilities**: calendar (always), email (if `emailsFilePath` /
+  `emailsOneDrivePath` is configured), contacts (if
+  `contactsFilePath` / `contactsOneDrivePath` is configured). All
+  read-only.
+- **Use case**: test fixtures, archived data, importing static data
+  into the same MCP surface.
+- **Write tools** will fail; check capabilities first.
+
+## Capability decision rule
+
+Before any write operation, look at the account's capabilities array:
+
+```text
+account.capabilities.find(c => c.name === "<category>")?.readOnly
+```
+
+- `undefined` → the account doesn't have that capability at all.
+- `true` → read-only; don't call the write tool.
+- `false` → safe to write.
+
+Combined with provider type, this prevents most "why did that fail?"
+moments before the call goes out.

--- a/src/CalendarMcp.Core/Skills/scenarios.md
+++ b/src/CalendarMcp.Core/Skills/scenarios.md
@@ -5,7 +5,7 @@ relevant single-domain guide (`email`, `calendar`, `contacts`,
 `attachments`) for tool-by-tool details; this guide focuses on
 sequencing.
 
-Every scenario assumes you have already called `ListAccounts` and
+Every scenario assumes you have already called `list_accounts` and
 know which `accountId` to use for each step.
 
 ## 1. Triage the morning inbox
@@ -14,7 +14,7 @@ Goal: quickly classify unread mail across all accounts and act on
 obvious clusters.
 
 ```
-1. GetEmails(unreadOnly=true, count=100)
+1. get_emails(unreadOnly=true, count=100)
    → fans out across all accounts, newest first
 
 2. (Optional, for a richer summary)
@@ -25,15 +25,15 @@ obvious clusters.
    → returns topic clusters + persona/account-mismatch analysis
 
 3. Group the result mentally (or via topic clusters):
-   - Newsletters / marketing → UnsubscribeFromEmail (high signal-to-noise)
-                              then BulkDeleteEmails
+   - Newsletters / marketing → unsubscribe_from_email (high signal-to-noise)
+                              then bulk_delete_emails
    - Meeting invites → keep, see scenario 6
    - Action-required → keep, address one-by-one
-   - Notifications → BulkMarkEmailsAsRead
+   - Notifications → bulk_mark_emails_as_read
 
 4. Apply in batches:
-   BulkDeleteEmails(items=[ {accountId, emailId}, ... ])
-   BulkMarkEmailsAsRead(items=[ ... ])
+   bulk_delete_emails(items=[ {accountId, emailId}, ... ])
+   bulk_mark_emails_as_read(items=[ ... ])
 ```
 
 ## 2. Schedule a meeting from an email thread
@@ -42,11 +42,11 @@ Goal: someone proposed a time over email; create the event with the
 right people.
 
 ```
-1. GetEmailDetails(accountId, emailId)
+1. get_email_details(accountId, emailId)
    → extract: from, to, cc → these are the candidate attendees
 
 2. Determine your free/busy:
-   GetCalendarEvents(
+   get_calendar_events(
      timeZone="<user TZ>",
      startDate=<proposed day>,
      endDate=<proposed day>,
@@ -54,7 +54,7 @@ right people.
    )
    → confirm the proposed slot is free; if not, suggest alternatives
 
-3. CreateEvent(
+3. create_event(
      accountId=<calendar account>,
      subject="<derived from email subject>",
      start="<proposed start ISO>",
@@ -64,7 +64,7 @@ right people.
      body="<short context referencing the email thread>"
    )
 
-4. (Optional) SendEmail(
+4. (Optional) send_email(
      to=[from, ...to, ...cc],
      subject="Re: <original>",
      body="Scheduled — calendar invite incoming.",
@@ -79,14 +79,14 @@ Goal: send a received email's attachment(s) to someone else.
 See `attachments` for the full pattern. Short form:
 
 ```
-1. GetEmailDetails(accountId, emailId)
+1. get_email_details(accountId, emailId)
    → response.attachments[].attachmentId   (provider-side IDs)
 
 2. For each attachment to forward:
-   GetEmailAttachment(accountId, emailId, attachmentId, mode="stash")
+   get_email_attachment(accountId, emailId, attachmentId, mode="stash")
    → response.attachmentId                  (server-stash ID)
 
-3. SendEmail(
+3. send_email(
      to=["forward@example.com"],
      subject="Fwd: <original>",
      body="<context>",
@@ -101,16 +101,16 @@ See `attachments` for the full pattern. Short form:
 ## 4. Respond to a meeting invite
 
 ```
-1. GetEmails(unreadOnly=true) or GetCalendarEvents(...)
+1. get_emails(unreadOnly=true) or get_calendar_events(...)
    → find the pending invite
 
-2. GetCalendarEventDetails(accountId, calendarId, eventId, timeZone)
+2. get_calendar_event_details(accountId, calendarId, eventId, timeZone)
    → review attendees, conflicts, agenda
 
-3. (Optional) GetCalendarEvents over the event's window
+3. (Optional) get_calendar_events over the event's window
    → check for overlaps
 
-4. RespondToEvent(
+4. respond_to_event(
      eventId,
      response="accept",  // or "tentative" / "decline"
      accountId=<the account that received the invite>,
@@ -124,15 +124,15 @@ See `attachments` for the full pattern. Short form:
 There is no free-busy/availability tool. Approximate it:
 
 ```
-1. GetCalendarEvents(timeZone="...", startDate, endDate, accountId=<own>)
+1. get_calendar_events(timeZone="...", startDate, endDate, accountId=<own>)
    → identify your free slots
 
 2. For each external participant where you have visibility:
-   GetCalendarEvents(timeZone="...", startDate, endDate, accountId=<their account if you have access>)
+   get_calendar_events(timeZone="...", startDate, endDate, accountId=<their account if you have access>)
 
 3. Intersect manually; propose top N candidate slots.
 
-4. SendEmail or CreateEvent with proposed times.
+4. send_email or create_event with proposed times.
 ```
 
 For colleagues whose calendars you cannot read, fall back to an email
@@ -141,21 +141,21 @@ proposal.
 ## 6. Bulk unsubscribe from marketing emails
 
 ```
-1. SearchEmails(query="unsubscribe", count=50)
+1. search_emails(query="unsubscribe", count=50)
    → likely-marketing candidates
 
 2. For each:
-   GetUnsubscribeInfo(accountId, emailId)
+   get_unsubscribe_info(accountId, emailId)
    → confirms List-Unsubscribe presence and which methods exist
 
-3. UnsubscribeFromEmail(accountId, emailId, method="auto")
+3. unsubscribe_from_email(accountId, emailId, method="auto")
    → executes the unsubscribe (one-click POST when available)
 
 4. After processing the batch:
-   BulkDeleteEmails(items=[ {accountId, emailId for each processed}, ... ])
+   bulk_delete_emails(items=[ {accountId, emailId for each processed}, ... ])
    → tidy up historical clutter
 
-Or skip step 2 and just call UnsubscribeFromEmail with method="auto" —
+Or skip step 2 and just call unsubscribe_from_email with method="auto" —
 it returns a clear error if no method is available, which you can
 ignore for those entries.
 ```
@@ -171,7 +171,7 @@ ignore for those entries.
    )
    → topic clusters, persona contexts, account mismatches
 
-2. GetCalendarEvents(
+2. get_calendar_events(
      timeZone=<user TZ>,
      startDate=<today>,
      endDate=<today>,
@@ -189,14 +189,14 @@ don't loop it.
 ## 8. Add the sender of an email as a contact
 
 ```
-1. GetEmailDetails(accountId, emailId)
+1. get_email_details(accountId, emailId)
    → from, fromName
 
-2. SearchContacts(query=fromEmail)
+2. search_contacts(query=fromEmail)
    → make sure they don't already exist
 
 3. If not found:
-   CreateContact(
+   create_contact(
      accountId=<same account as the email, or pick deliberately>,
      displayName=fromName,
      email=fromEmail
@@ -210,12 +210,12 @@ no cross-account move tool, but you can forward then delete:
 
 ```
 For each mismatch entry:
-  GetEmailDetails(receivedOnAccount, emailId)
+  get_email_details(receivedOnAccount, emailId)
   → get full body + attachments
 
   Forward to yourself on expectedAccount:
-    Optionally stash attachments via GetEmailAttachment
-    SendEmail(
+    Optionally stash attachments via get_email_attachment
+    send_email(
       to=[<your address on expectedAccount>],
       subject="Re-routed: " + original.subject,
       body=original.body,
@@ -223,7 +223,7 @@ For each mismatch entry:
       attachments=[ ... ]
     )
 
-  DeleteEmail(receivedOnAccount, emailId)
+  delete_email(receivedOnAccount, emailId)
 ```
 
 This is destructive; only do it after user confirmation.
@@ -231,7 +231,7 @@ This is destructive; only do it after user confirmation.
 ## 10. Cross-account search for a topic
 
 ```
-SearchEmails(query="<topic>")    // omit accountId → fans out
+search_emails(query="<topic>")    // omit accountId → fans out
 → results carry their own accountId; preserve it for follow-up calls
 ```
 

--- a/src/CalendarMcp.Core/Skills/scenarios.md
+++ b/src/CalendarMcp.Core/Skills/scenarios.md
@@ -1,0 +1,243 @@
+# Scenarios
+
+End-to-end workflows that wire multiple tools together. Read the
+relevant single-domain guide (`email`, `calendar`, `contacts`,
+`attachments`) for tool-by-tool details; this guide focuses on
+sequencing.
+
+Every scenario assumes you have already called `ListAccounts` and
+know which `accountId` to use for each step.
+
+## 1. Triage the morning inbox
+
+Goal: quickly classify unread mail across all accounts and act on
+obvious clusters.
+
+```
+1. GetEmails(unreadOnly=true, count=100)
+   → fans out across all accounts, newest first
+
+2. (Optional, for a richer summary)
+   get_contextual_email_summary(
+     unreadOnly=true,
+     includeBodyPreview=true
+   )
+   → returns topic clusters + persona/account-mismatch analysis
+
+3. Group the result mentally (or via topic clusters):
+   - Newsletters / marketing → UnsubscribeFromEmail (high signal-to-noise)
+                              then BulkDeleteEmails
+   - Meeting invites → keep, see scenario 6
+   - Action-required → keep, address one-by-one
+   - Notifications → BulkMarkEmailsAsRead
+
+4. Apply in batches:
+   BulkDeleteEmails(items=[ {accountId, emailId}, ... ])
+   BulkMarkEmailsAsRead(items=[ ... ])
+```
+
+## 2. Schedule a meeting from an email thread
+
+Goal: someone proposed a time over email; create the event with the
+right people.
+
+```
+1. GetEmailDetails(accountId, emailId)
+   → extract: from, to, cc → these are the candidate attendees
+
+2. Determine your free/busy:
+   GetCalendarEvents(
+     timeZone="<user TZ>",
+     startDate=<proposed day>,
+     endDate=<proposed day>,
+     accountId=<calendar account>
+   )
+   → confirm the proposed slot is free; if not, suggest alternatives
+
+3. CreateEvent(
+     accountId=<calendar account>,
+     subject="<derived from email subject>",
+     start="<proposed start ISO>",
+     end="<proposed end ISO>",
+     timeZone="<user TZ>",
+     attendees=[from, ...to, ...cc],
+     body="<short context referencing the email thread>"
+   )
+
+4. (Optional) SendEmail(
+     to=[from, ...to, ...cc],
+     subject="Re: <original>",
+     body="Scheduled — calendar invite incoming.",
+     accountId=<same account the original was received on>
+   )
+```
+
+## 3. Forward an email with attachments
+
+Goal: send a received email's attachment(s) to someone else.
+
+See `attachments` for the full pattern. Short form:
+
+```
+1. GetEmailDetails(accountId, emailId)
+   → response.attachments[].attachmentId   (provider-side IDs)
+
+2. For each attachment to forward:
+   GetEmailAttachment(accountId, emailId, attachmentId, mode="stash")
+   → response.attachmentId                  (server-stash ID)
+
+3. SendEmail(
+     to=["forward@example.com"],
+     subject="Fwd: <original>",
+     body="<context>",
+     accountId=<same account or pick deliberately>,
+     attachments=[
+       { "attachmentId": "<stash-id-1>" },
+       { "attachmentId": "<stash-id-2>" }
+     ]
+   )
+```
+
+## 4. Respond to a meeting invite
+
+```
+1. GetEmails(unreadOnly=true) or GetCalendarEvents(...)
+   → find the pending invite
+
+2. GetCalendarEventDetails(accountId, calendarId, eventId, timeZone)
+   → review attendees, conflicts, agenda
+
+3. (Optional) GetCalendarEvents over the event's window
+   → check for overlaps
+
+4. RespondToEvent(
+     eventId,
+     response="accept",  // or "tentative" / "decline"
+     accountId=<the account that received the invite>,
+     calendarId=<from event details>,
+     comment="<optional note to organizer>"
+   )
+```
+
+## 5. Find time across multiple participants
+
+There is no free-busy/availability tool. Approximate it:
+
+```
+1. GetCalendarEvents(timeZone="...", startDate, endDate, accountId=<own>)
+   → identify your free slots
+
+2. For each external participant where you have visibility:
+   GetCalendarEvents(timeZone="...", startDate, endDate, accountId=<their account if you have access>)
+
+3. Intersect manually; propose top N candidate slots.
+
+4. SendEmail or CreateEvent with proposed times.
+```
+
+For colleagues whose calendars you cannot read, fall back to an email
+proposal.
+
+## 6. Bulk unsubscribe from marketing emails
+
+```
+1. SearchEmails(query="unsubscribe", count=50)
+   → likely-marketing candidates
+
+2. For each:
+   GetUnsubscribeInfo(accountId, emailId)
+   → confirms List-Unsubscribe presence and which methods exist
+
+3. UnsubscribeFromEmail(accountId, emailId, method="auto")
+   → executes the unsubscribe (one-click POST when available)
+
+4. After processing the batch:
+   BulkDeleteEmails(items=[ {accountId, emailId for each processed}, ... ])
+   → tidy up historical clutter
+
+Or skip step 2 and just call UnsubscribeFromEmail with method="auto" —
+it returns a clear error if no method is available, which you can
+ignore for those entries.
+```
+
+## 7. Daily summary across all accounts
+
+```
+1. get_contextual_email_summary(
+     countPerAccount=50,
+     unreadOnly=false,
+     includeBodyPreview=true,
+     maxSamplesPerCluster=3
+   )
+   → topic clusters, persona contexts, account mismatches
+
+2. GetCalendarEvents(
+     timeZone=<user TZ>,
+     startDate=<today>,
+     endDate=<today>,
+     accountId=<each calendar-capable account>
+   )
+   → today's agenda per persona
+
+3. Compose a brief: top clusters, urgent items, today's meetings,
+   notable account mismatches.
+```
+
+`get_contextual_email_summary` is heavy — once per session is fine,
+don't loop it.
+
+## 8. Add the sender of an email as a contact
+
+```
+1. GetEmailDetails(accountId, emailId)
+   → from, fromName
+
+2. SearchContacts(query=fromEmail)
+   → make sure they don't already exist
+
+3. If not found:
+   CreateContact(
+     accountId=<same account as the email, or pick deliberately>,
+     displayName=fromName,
+     email=fromEmail
+   )
+```
+
+## 9. Move a misdirected email to the right account
+
+`get_contextual_email_summary` reports `accountMismatches`. There is
+no cross-account move tool, but you can forward then delete:
+
+```
+For each mismatch entry:
+  GetEmailDetails(receivedOnAccount, emailId)
+  → get full body + attachments
+
+  Forward to yourself on expectedAccount:
+    Optionally stash attachments via GetEmailAttachment
+    SendEmail(
+      to=[<your address on expectedAccount>],
+      subject="Re-routed: " + original.subject,
+      body=original.body,
+      accountId=receivedOnAccount,
+      attachments=[ ... ]
+    )
+
+  DeleteEmail(receivedOnAccount, emailId)
+```
+
+This is destructive; only do it after user confirmation.
+
+## 10. Cross-account search for a topic
+
+```
+SearchEmails(query="<topic>")    // omit accountId → fans out
+→ results carry their own accountId; preserve it for follow-up calls
+```
+
+For richer cross-account analysis (which account, what cluster, who's
+been talking about it):
+
+```
+get_contextual_email_summary(topics="<topic>")
+```

--- a/src/CalendarMcp.Core/Tools/GetGuideTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetGuideTool.cs
@@ -91,7 +91,7 @@ public sealed class GetGuideTool(ILogger<GetGuideTool> logger)
         var sb = new StringBuilder();
         sb.AppendLine("# Calendar MCP — Available Guides");
         sb.AppendLine();
-        sb.AppendLine("Call `GetGuide` with `name=<topic>` (e.g. `GetGuide(name=\"overview\")`) to read any guide below.");
+        sb.AppendLine("Call `get_guide` with `name=<topic>` (e.g. `get_guide(name=\"overview\")`) to read any guide below.");
         sb.AppendLine();
         sb.AppendLine("| Guide | Description |");
         sb.AppendLine("|---|---|");

--- a/src/CalendarMcp.Core/Tools/GetGuideTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetGuideTool.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace CalendarMcp.Core.Tools;
+
+/// <summary>
+/// Returns markdown "skill" documents that describe how to use Calendar MCP
+/// effectively for specific tasks. Files live as embedded resources under
+/// <c>CalendarMcp.Core/Skills/*.md</c>; callers fetch them by name.
+/// </summary>
+[McpServerToolType]
+public sealed class GetGuideTool(ILogger<GetGuideTool> logger)
+{
+    private const string ResourcePrefix = "CalendarMcp.Core.Skills.";
+    private const string ResourceSuffix = ".md";
+    private static readonly Assembly SkillsAssembly = typeof(GetGuideTool).Assembly;
+
+    // Short one-line descriptions for each known guide. Drives the index
+    // response so the agent can pick the right guide on the first call
+    // without reading every file. Add a new entry when adding a new .md.
+    private static readonly Dictionary<string, string> GuideDescriptions = new(StringComparer.Ordinal)
+    {
+        ["overview"] = "Start here. Capability matrix, provider summary, and pointers to every other guide.",
+        ["accounts"] = "How accounts work: discovery, capabilities, multi-account routing, and domain matching.",
+        ["email"] = "All email tools and common patterns: list, search, read details, send, organize, bulk operations.",
+        ["calendar"] = "Calendar tools and patterns: list, create, update, respond. Timezone handling is mandatory.",
+        ["contacts"] = "Contact tools: list, search, view, create, update, delete across providers that support contacts.",
+        ["attachments"] = "Non-obvious attachment flow: stash vs inline modes, upload/forward patterns, size limits.",
+        ["scenarios"] = "End-to-end workflows wiring tools together: triage, scheduling, forwarding, bulk cleanup.",
+        ["providers"] = "Per-provider behavior: Microsoft 365, Google, Outlook.com, IMAP/SMTP, ICS, JSON.",
+    };
+
+    [McpServerTool, Description(
+        "Returns a markdown guide explaining how to use the Calendar MCP server for a specific topic. " +
+        "Call with no arguments (or name='index') to get the list of available guides. " +
+        "Read 'overview' first if you have not used this server before. " +
+        "Read the topic-specific guide before attempting a non-trivial workflow (e.g., 'attachments' before forwarding files, 'scenarios' for multi-tool flows).")]
+    public string GetGuide(
+        [Description("The guide name without extension, e.g. 'overview', 'accounts', 'email', 'calendar', 'contacts', 'attachments', 'scenarios', 'providers'. Omit (or pass 'index') to list available guides.")]
+        string? name = null)
+    {
+        logger.LogInformation("GetGuide called with name='{Name}'", name ?? "(null)");
+
+        if (string.IsNullOrWhiteSpace(name) || name.Equals("index", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildIndex();
+        }
+
+        if (!IsValidGuideName(name))
+            throw new McpException($"Invalid guide name '{name}'. Use letters, digits, dashes, or underscores; max 64 chars.");
+
+        var resourceName = ResourcePrefix + name + ResourceSuffix;
+        using var stream = SkillsAssembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            var available = string.Join(", ", ListGuideNames());
+            throw new McpException($"Guide '{name}' not found. Available guides: {available}.");
+        }
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static bool IsValidGuideName(string name)
+    {
+        if (name.Length is 0 or > 64) return false;
+        foreach (var c in name)
+        {
+            if (!(char.IsLetterOrDigit(c) || c == '-' || c == '_'))
+                return false;
+        }
+        return true;
+    }
+
+    private static IEnumerable<string> ListGuideNames()
+    {
+        return SkillsAssembly.GetManifestResourceNames()
+            .Where(n => n.StartsWith(ResourcePrefix, StringComparison.Ordinal)
+                        && n.EndsWith(ResourceSuffix, StringComparison.Ordinal))
+            .Select(n => n[ResourcePrefix.Length..^ResourceSuffix.Length])
+            .OrderBy(n => n, StringComparer.Ordinal);
+    }
+
+    private static string BuildIndex()
+    {
+        var names = ListGuideNames().ToList();
+        var sb = new StringBuilder();
+        sb.AppendLine("# Calendar MCP — Available Guides");
+        sb.AppendLine();
+        sb.AppendLine("Call `GetGuide` with `name=<topic>` (e.g. `GetGuide(name=\"overview\")`) to read any guide below.");
+        sb.AppendLine();
+        sb.AppendLine("| Guide | Description |");
+        sb.AppendLine("|---|---|");
+        foreach (var n in names)
+        {
+            var desc = GuideDescriptions.TryGetValue(n, out var d) ? d : "(no description)";
+            sb.Append("| `").Append(n).Append("` | ").Append(desc).AppendLine(" |");
+        }
+        sb.AppendLine();
+        sb.AppendLine("## Suggested reading order");
+        sb.AppendLine();
+        sb.AppendLine("1. **First time?** Read `overview`, then `accounts`.");
+        sb.AppendLine("2. **Sending email with files?** Read `email` + `attachments`.");
+        sb.AppendLine("3. **Scheduling a meeting?** Read `calendar` (timezones matter) + relevant entries in `scenarios`.");
+        sb.AppendLine("4. **Triaging mail across accounts?** Read `email` + `scenarios`.");
+        sb.AppendLine("5. **Provider-specific behavior** (e.g., IMAP folder names, ICS read-only): Read `providers`.");
+        return sb.ToString();
+    }
+}

--- a/src/CalendarMcp.HttpServer/Program.cs
+++ b/src/CalendarMcp.HttpServer/Program.cs
@@ -126,7 +126,7 @@ public class Program
 
         // Configure MCP server with HTTP/SSE transport and register tools
         builder.Services
-            .AddMcpServer()
+            .AddMcpServer(CalendarMcpServerOptions.Configure)
             .WithHttpTransport()
             .WithTools<CalendarMcp.Core.Tools.ListAccountsTool>()
             .WithTools<CalendarMcp.Core.Tools.GetEmailsTool>()

--- a/src/CalendarMcp.HttpServer/Program.cs
+++ b/src/CalendarMcp.HttpServer/Program.cs
@@ -129,6 +129,7 @@ public class Program
             .AddMcpServer(CalendarMcpServerOptions.Configure)
             .WithHttpTransport()
             .WithTools<CalendarMcp.Core.Tools.ListAccountsTool>()
+            .WithTools<CalendarMcp.Core.Tools.GetGuideTool>()
             .WithTools<CalendarMcp.Core.Tools.GetEmailsTool>()
             .WithTools<CalendarMcp.Core.Tools.GetEmailDetailsTool>()
             .WithTools<CalendarMcp.Core.Tools.GetEmailAttachmentTool>()

--- a/src/CalendarMcp.HttpServer/Program.cs
+++ b/src/CalendarMcp.HttpServer/Program.cs
@@ -233,7 +233,7 @@ public class Program
         {
             Log.Information("Calendar MCP HTTP Server listening on {Url}", url);
         }
-        Log.Information("  MCP endpoint:  /mcp");
+        Log.Information("  MCP endpoint:  /");
         Log.Information("  Admin API:     /admin");
         Log.Information("  Admin UI:      /admin/ui");
         Log.Information("  API Docs:      /scalar/v1");

--- a/src/CalendarMcp.StdioServer/Program.cs
+++ b/src/CalendarMcp.StdioServer/Program.cs
@@ -113,7 +113,7 @@ public class Program
                 services.AddCalendarMcpCore();
                 
                 // Configure MCP server with stdio transport and register tools
-                services.AddMcpServer()
+                services.AddMcpServer(CalendarMcpServerOptions.Configure)
                     .WithTools<CalendarMcp.Core.Tools.ListAccountsTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailsTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailDetailsTool>()

--- a/src/CalendarMcp.StdioServer/Program.cs
+++ b/src/CalendarMcp.StdioServer/Program.cs
@@ -115,6 +115,7 @@ public class Program
                 // Configure MCP server with stdio transport and register tools
                 services.AddMcpServer(CalendarMcpServerOptions.Configure)
                     .WithTools<CalendarMcp.Core.Tools.ListAccountsTool>()
+                    .WithTools<CalendarMcp.Core.Tools.GetGuideTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailsTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailDetailsTool>()
                     .WithTools<CalendarMcp.Core.Tools.GetEmailAttachmentTool>()


### PR DESCRIPTION
## Summary

- Set the MCP `ServerInfo` (Name/Title/Description/Version) on both the stdio and HTTP entry points. `Version` is read from `AssemblyInformationalVersion` so it tracks `Directory.Build.props` automatically; `Description` enumerates the full provider matrix (M365, Google, Outlook.com, IMAP/SMTP, ICS, JSON) and now points clients at the new `GetGuide` tool. Also sets `ServerInstructions` so clients see a short orientation at initialize time.
- Add a `GetGuide` tool that returns markdown content from a fixed set of embedded resources under `CalendarMcp.Core/Skills/*.md`. Calling with no argument (or `name="index"`) returns a generated index; calling with a guide name returns the content. Name input is validated to `[A-Za-z0-9_-]{1,64}` so the embedded-resource namespace cannot be walked.
- Seed with 8 comprehensive guides totaling ~1,100 lines: `overview`, `accounts`, `email`, `calendar`, `contacts`, `attachments` (the non-obvious stash/upload/forward flow with both ID namespaces called out), `scenarios` (10 end-to-end multi-tool workflows), and `providers` (per-provider quirks: M365 3 MB attachment cap, Gmail labels-vs-folders, ICS/JSON read-only enforcement, IMAP folder mapping).

Both `Program.cs` files now pass `CalendarMcpServerOptions.Configure` to `AddMcpServer(...)` and register `GetGuideTool` alongside the other tools. Adding new guides later is a 2-file change: drop a `.md` into `Skills/` and add a one-line entry to `GuideDescriptions` in `GetGuideTool.cs`.

## Test plan

- [x] `dotnet build calendar-mcp.slnx` — 0 errors (warnings are pre-existing NuGet vuln warnings)
- [x] `dotnet test calendar-mcp.slnx` — 243/243 pass, no test changes needed since the new tool has no behavior beyond reading embedded resources and the server-options change only affects the initialize handshake
- [x] Verified all 8 `.md` files are embedded as `CalendarMcp.Core.Skills.*.md` resources in the built DLL
- [ ] Manual: connect an MCP client and confirm `ServerInfo` includes `Title="Calendar MCP"`, a non-empty `Description`, and `Version` matching `Directory.Build.props`
- [ ] Manual: call `GetGuide()` and confirm the generated index lists all 8 guides; call `GetGuide(name="overview")` and confirm the content

🤖 Generated with [Claude Code](https://claude.com/claude-code)