### PR TITLE
Cross-link guides to prompts and add three new prompts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.3.2</VersionPrefix>
+    <VersionPrefix>1.3.3</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.2</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
+++ b/src/CalendarMcp.Core/Configuration/CalendarMcpServerOptions.cs
@@ -30,6 +30,14 @@ public static class CalendarMcpServerOptions
         Call it with no arguments (or name='index') to see the list of available guides,
         then call it again with a topic name to read that guide.
 
+        This server also exposes MCP prompts that encode the canonical multi-step
+        flows for common tasks — prefer them over orchestrating tools by hand when
+        the user's request matches one:
+        - Calendar: `daily_briefing`, `week_ahead`, `schedule_meeting`, `respond_to_invite`
+        - Email: `email_triage`, `draft_reply`, `find_emails_about`,
+          `forward_with_attachments`, `bulk_unsubscribe`
+        - Contacts: `contact_summary`
+
         Provider capability summary:
         - Microsoft 365 / Google Workspace / Outlook.com: email, calendar, contacts (read/write)
         - IMAP + SMTP: email only (read/write)

--- a/src/CalendarMcp.Core/Prompts/CalendarPrompts.cs
+++ b/src/CalendarMcp.Core/Prompts/CalendarPrompts.cs
@@ -61,6 +61,46 @@ public sealed class CalendarPrompts
             """;
     }
 
+    [McpServerPrompt(Name = "respond_to_invite"), Description(
+        "Reviews a meeting invite — including conflicts — and submits an accept / tentative / decline response " +
+        "from the correct account.")]
+    public string RespondToInvite(
+        [Description("Event ID of the invite. Obtain from get_calendar_events or the originating email thread.")] string eventId,
+        [Description("Account ID that received the invite. Required — defaulting to the first account often picks the wrong calendar.")] string accountId,
+        [Description("Calendar ID the event lives on. Obtain from get_calendar_events.")] string calendarId,
+        [Description("Response: 'accept', 'tentative', or 'decline'.")] string response,
+        [Description("IANA timezone name (e.g. 'America/Chicago'). Required.")] string timeZone,
+        [Description("Optional note to send to the organizer with the response.")] string? comment = null)
+    {
+        var commentHint = string.IsNullOrWhiteSpace(comment)
+            ? "No comment was provided. Ask me if I want to add one before sending the response."
+            : $"Include this comment with the response: \"{comment}\"";
+
+        return $"""
+            Please help me respond to a meeting invite. Follow these steps:
+
+            1. Call get_calendar_event_details with accountId="{accountId}", calendarId="{calendarId}", eventId="{eventId}", timeZone="{timeZone}".
+               Review subject, time (in {timeZone}), location, attendees, and body.
+
+            2. Check for conflicts:
+               Call get_calendar_events with timeZone="{timeZone}", accountId="{accountId}", and a startDate/endDate covering the invite's day.
+               Report any overlapping events.
+
+            3. Summarise the invite + conflicts to me and confirm I want to respond "{response}".
+
+            4. {commentHint}
+
+            5. Call respond_to_event:
+               - eventId="{eventId}"
+               - accountId="{accountId}"  (must match the account that received the invite)
+               - calendarId="{calendarId}"
+               - response="{response}"
+               - comment=<the comment if provided>
+
+            6. Confirm the response was submitted.
+            """;
+    }
+
     [McpServerPrompt(Name = "schedule_meeting"), Description(
         "Guides the assistant to find available times and create a calendar event. " +
         "Provide the meeting title, duration, and attendee email addresses to get started.")]

--- a/src/CalendarMcp.Core/Prompts/EmailPrompts.cs
+++ b/src/CalendarMcp.Core/Prompts/EmailPrompts.cs
@@ -66,6 +66,83 @@ public sealed class EmailPrompts
             """;
     }
 
+    [McpServerPrompt(Name = "forward_with_attachments"), Description(
+        "Forwards a received email — including its attachments — to one or more recipients. " +
+        "Handles the two-step stash flow so attachment bytes never round-trip through the agent.")]
+    public string ForwardWithAttachments(
+        [Description("Email ID of the message to forward. Obtain from get_emails or search_emails.")] string emailId,
+        [Description("Account ID the email belongs to. Obtain from list_accounts.")] string accountId,
+        [Description("Comma-separated list of recipient email addresses to forward to.")] string forwardTo,
+        [Description("Optional note to prepend to the forwarded body. Defaults to a short 'FYI — forwarding this' line.")] string? note = null)
+    {
+        var noteLine = string.IsNullOrWhiteSpace(note)
+            ? "FYI — forwarding this."
+            : note;
+
+        return $$"""
+            Please forward an email with its attachments. Follow these steps in order — the attachment flow is non-obvious, so do not skip steps:
+
+            1. Call get_email_details with emailId="{{emailId}}" and accountId="{{accountId}}".
+               - Capture the subject, body, and attachments[] array.
+               - Each attachment carries a provider-side attachmentId — this is NOT the ID you pass to send_email.
+
+            2. For each attachment in the response:
+               Call get_email_attachment with accountId="{{accountId}}", emailId="{{emailId}}", attachmentId=<provider-side ID>, mode="stash".
+               - This returns a server-stash attachmentId (different namespace from the provider's).
+               - Stash IDs are single-use; they're consumed by the send below.
+
+            3. Call send_email:
+               - accountId="{{accountId}}" (forward from the same account that received the original)
+               - to=[<each address in "{{forwardTo}}">]
+               - subject="Fwd: <original subject>"
+               - body=<noteLine> + "\n\n---\n\n" + original body
+               - attachments=[{ "attachmentId": <stash-id-1> }, { "attachmentId": <stash-id-2> }, ...]
+
+            Note to include: {{noteLine}}
+
+            4. Confirm the forward was sent and report how many attachments were included.
+
+            If any attachment exceeds provider limits (3 MB on M365/Outlook.com, 25 MB on Google), surface the error to the user — don't retry blindly.
+            """;
+    }
+
+    [McpServerPrompt(Name = "bulk_unsubscribe"), Description(
+        "Finds likely-marketing emails, unsubscribes from them using RFC-compliant List-Unsubscribe methods, " +
+        "and optionally deletes the historical clutter afterwards.")]
+    public string BulkUnsubscribe(
+        [Description("Optional search query to bias which messages are considered (e.g. 'newsletter', 'marketing'). Defaults to 'unsubscribe' which matches most legitimate bulk mail.")] string? searchQuery = null,
+        [Description("Account ID to limit the search to. Omit to scan all accounts.")] string? accountId = null,
+        [Description("Set to true to also delete the matched messages after unsubscribing. Defaults to false — present the list to the user first.")] bool deleteAfter = false)
+    {
+        var query = string.IsNullOrWhiteSpace(searchQuery) ? "unsubscribe" : searchQuery;
+        var accountHint = accountId != null
+            ? $"Search only in account '{accountId}'."
+            : "Search across all accounts.";
+        var deleteHint = deleteAfter
+            ? "After the user confirms, call bulk_delete_emails with the items you successfully unsubscribed from."
+            : "Do NOT delete anything in this run — just unsubscribe. Tell the user they can run a follow-up to clean up history.";
+
+        return $"""
+            Please help me unsubscribe from marketing emails. Follow these steps:
+
+            1. Call search_emails with query="{query}", count=50{(accountId != null ? $", accountId=\"{accountId}\"" : "")}. {accountHint}
+
+            2. Present the candidate list to me (sender, subject, account) and ask which to skip, if any. Do not proceed silently — bulk unsubscribe is hard to reverse.
+
+            3. For each remaining candidate:
+               a. Call get_unsubscribe_info with its accountId and emailId to confirm a List-Unsubscribe method exists.
+               b. If a method is available, call unsubscribe_from_email with method="auto" — this prefers one-click POST, then falls back to HTTPS URL, then mailto.
+               c. If no method is available, skip that message and note it in the summary.
+
+            4. Report back:
+               - How many we tried to unsubscribe from.
+               - How many succeeded (one-click vs URL returned vs mailto sent).
+               - How many had no unsubscribe method.
+
+            5. {deleteHint}
+            """;
+    }
+
     [McpServerPrompt(Name = "find_emails_about"), Description(
         "Searches emails for a topic and summarises the findings. " +
         "Useful for researching a thread or finding past correspondence on a subject.")]

--- a/src/CalendarMcp.Core/Skills/attachments.md
+++ b/src/CalendarMcp.Core/Skills/attachments.md
@@ -82,6 +82,11 @@ content (e.g., to OCR an image, parse a small PDF). Files larger than
 
 ## Forwarding flow (the most common pattern)
 
+> **Prompt shortcut:** the `forward_with_attachments` prompt wraps this
+> entire flow. Pass `emailId`, `accountId`, `forwardTo`, and an optional
+> `note`; the prompt expands to the same steps shown below. Prefer it
+> when the host supports MCP prompts.
+
 ```
 get_email_details(accountId, emailId)
   → response.attachments[]   // each has provider-side attachmentId

--- a/src/CalendarMcp.Core/Skills/calendar.md
+++ b/src/CalendarMcp.Core/Skills/calendar.md
@@ -98,6 +98,9 @@ than orchestrating the steps below by hand.
 
 ### Show my week
 
+> Use the `week_ahead` prompt — it groups by day and highlights busy
+> days automatically. For just today + unread mail, use `daily_briefing`.
+
 ```
 list_accounts → pick calendar-capable account(s)
 get_calendar_events(
@@ -110,6 +113,10 @@ get_calendar_events(
 ```
 
 ### Schedule a 30-minute meeting tomorrow at 10 AM
+
+> Use the `schedule_meeting` prompt when you need to find a free slot
+> first; use the direct `create_event` call below only when the slot
+> is already known.
 
 ```
 create_event(
@@ -133,6 +140,10 @@ update_event(accountId, calendarId, eventId,
 ```
 
 ### Respond to an invite
+
+> Use the `respond_to_invite` prompt — it adds a conflict check before
+> responding and enforces the always-pass-`accountId`/`calendarId`/`timeZone`
+> contract that's easy to violate by hand.
 
 ```
 get_calendar_events(...)                       // find pending invites

--- a/src/CalendarMcp.Core/Skills/calendar.md
+++ b/src/CalendarMcp.Core/Skills/calendar.md
@@ -74,6 +74,26 @@ attendees automatically.
   configured account, which typically does not have the invitation.
 - `comment` is optional message text sent with the response.
 
+## Prompt shortcuts
+
+This server exposes MCP prompts that wrap the common calendar
+workflows. When the host supports prompts, prefer them:
+
+- **`daily_briefing`** — today's events + unread email across all
+  accounts. Pass `timeZone`.
+- **`week_ahead`** — 7-day overview grouped by day, with highlights.
+  Pass `timeZone`.
+- **`schedule_meeting`** — find an open slot and create the event.
+  Pass `title`, `durationMinutes`, comma-separated `attendees`,
+  `timeZone`, and optional `preferredDate`.
+- **`respond_to_invite`** — review an invite with conflict check, then
+  accept / tentative / decline from the correct account. Pass
+  `eventId`, `accountId`, `calendarId`, `response`, `timeZone`, and an
+  optional `comment`.
+
+If the user's request matches one of these, invoke the prompt rather
+than orchestrating the steps below by hand.
+
 ## Common patterns
 
 ### Show my week

--- a/src/CalendarMcp.Core/Skills/contacts.md
+++ b/src/CalendarMcp.Core/Skills/contacts.md
@@ -52,6 +52,10 @@ Permanent on most providers; no per-tool soft-delete or recovery.
 
 ### Find a contact by name or company
 
+> Use the `contact_summary` prompt when you also want recent
+> correspondence with the person — it adds a `search_emails` step
+> automatically.
+
 ```
 search_contacts(query="Acme")    // fans out across accounts
 → examine results, pick the right one

--- a/src/CalendarMcp.Core/Skills/contacts.md
+++ b/src/CalendarMcp.Core/Skills/contacts.md
@@ -41,6 +41,13 @@ optional. Pass only what changes.
 
 Permanent on most providers; no per-tool soft-delete or recovery.
 
+## Prompt shortcuts
+
+- **`contact_summary`** — builds a cross-account profile for a person
+  by name or email, including recent correspondence. Pass
+  `nameOrEmail`. When the host supports prompts, prefer this over
+  hand-wiring `search_contacts` + `get_contact_details` + `search_emails`.
+
 ## Common patterns
 
 ### Find a contact by name or company

--- a/src/CalendarMcp.Core/Skills/email.md
+++ b/src/CalendarMcp.Core/Skills/email.md
@@ -122,6 +122,8 @@ than rebuilding the steps yourself.
 
 ### Triage unread
 
+> Use the `email_triage` prompt for this — it wraps the loop below.
+
 ```
 get_emails(unreadOnly=true, count=50)   // fans out across all accounts
 → for each:
@@ -132,6 +134,8 @@ get_emails(unreadOnly=true, count=50)   // fans out across all accounts
 
 ### Find then read
 
+> Use the `find_emails_about` prompt for a topic search + summary.
+
 ```
 search_emails(query="invoice december")
 → pick the right hit
@@ -140,12 +144,18 @@ search_emails(query="invoice december")
 
 ### Reply with the same account that received
 
+> Use the `draft_reply` prompt to handle this end-to-end (read original,
+> draft in a chosen tone, confirm, send from the correct account).
+
 When replying, always pass the original message's `accountId` to
 `send_email` so the reply goes from the right persona. Smart routing
 will sometimes pick correctly via the recipient domain, but not
 always — be explicit.
 
 ### Bulk unsubscribe newsletters
+
+> Use the `bulk_unsubscribe` prompt — it bakes in the "confirm with
+> the user before mass-unsubscribing" step that's easy to forget.
 
 ```
 search_emails(query="unsubscribe", count=50)

--- a/src/CalendarMcp.Core/Skills/email.md
+++ b/src/CalendarMcp.Core/Skills/email.md
@@ -97,6 +97,27 @@ that may have been sent to the wrong account ("mismatches"), and
 profiles each account's "persona" (top sender domains, primary
 topics). Use for daily/weekly triage, not for routine lookups.
 
+## Prompt shortcuts
+
+This server exposes MCP prompts that wrap the most common email
+workflows. When the host supports prompts, prefer them over manual
+orchestration:
+
+- **`email_triage`** — wraps the "triage unread" pattern below. Pass
+  optional `focusTopics` to bias the classification.
+- **`draft_reply`** — wraps the "reply with the same account that
+  received" pattern. Pass `emailId`, `accountId`, and a `tone`.
+- **`find_emails_about`** — wraps the "find then read" pattern as a
+  topic search + summary. Pass a `topic` (and optional `accountId`).
+- **`forward_with_attachments`** — wraps the forward flow including the
+  non-obvious attachment stash sequence (see `attachments`). Pass
+  `emailId`, `accountId`, `forwardTo`, and an optional `note`.
+- **`bulk_unsubscribe`** — wraps the unsubscribe-then-cleanup pattern.
+  Pass an optional `searchQuery`, `accountId`, and `deleteAfter` flag.
+
+If the user's request matches one of these, invoke the prompt rather
+than rebuilding the steps yourself.
+
 ## Common patterns
 
 ### Triage unread

--- a/src/CalendarMcp.Core/Skills/overview.md
+++ b/src/CalendarMcp.Core/Skills/overview.md
@@ -29,6 +29,32 @@ every configured account; capabilities vary per provider.
 `RW` = read/write, `R` = read-only, `R*` = read-only and optional per
 account configuration.
 
+## Prompts (workflow shortcuts)
+
+In addition to tools, this server exposes **MCP prompts** — pre-built
+workflow templates that the host application can offer to the user as
+one-click starters. If your client supports prompts (Claude Desktop,
+many IDE plugins), prefer invoking the matching prompt instead of
+hand-orchestrating the underlying tool calls:
+
+| Prompt | What it does | Replaces |
+|---|---|---|
+| `daily_briefing` | Today's events + unread email across all accounts | manual fan-out of `get_calendar_events` + `get_emails` |
+| `week_ahead` | 7-day calendar overview grouped by day | `get_calendar_events` for a week + presentation |
+| `schedule_meeting` | Find a free slot and create the event | `get_calendar_events` + `create_event` |
+| `respond_to_invite` | Review an invite with conflicts and submit accept/tentative/decline | `get_calendar_event_details` + `get_calendar_events` + `respond_to_event` |
+| `email_triage` | Classify unread mail into action / FYI / ignore | `get_emails(unreadOnly=true)` + reasoning |
+| `draft_reply` | Read an email and draft a reply in a given tone | `get_email_details` + `send_email` |
+| `find_emails_about` | Search a topic and summarize findings | `search_emails` + `get_email_details` × N |
+| `forward_with_attachments` | Forward an email plus its files using the stash flow | `get_email_details` + `get_email_attachment` × N + `send_email` |
+| `bulk_unsubscribe` | Find marketing mail, unsubscribe, optionally clean up | `search_emails` + `get_unsubscribe_info` + `unsubscribe_from_email` (+ `bulk_delete_emails`) |
+| `contact_summary` | Cross-account profile for a person | `search_contacts` + `get_contact_details` + `search_emails` |
+
+The guides for each domain (`email`, `calendar`, `contacts`,
+`scenarios`) call out which prompt maps to which workflow. When a
+prompt fits the user's request, using it is faster and more reliable
+than reconstructing the steps yourself.
+
 ## Tool categories
 
 - **Accounts / meta**: `list_accounts`, `get_guide`

--- a/src/CalendarMcp.Core/Skills/scenarios.md
+++ b/src/CalendarMcp.Core/Skills/scenarios.md
@@ -8,6 +8,27 @@ sequencing.
 Every scenario assumes you have already called `list_accounts` and
 know which `accountId` to use for each step.
 
+## Prompts cover several of these end-to-end
+
+If the MCP client supports prompts, prefer the prompt over the manual
+sequence — it's a single invocation that expands to an equivalent
+plan and reduces the chance of mis-ordering steps:
+
+| Scenario below | Equivalent prompt |
+|---|---|
+| 1. Triage the morning inbox | `email_triage` |
+| 2. Schedule a meeting from an email thread | `schedule_meeting` (after extracting attendees from the thread) |
+| 3. Forward an email with attachments | `forward_with_attachments` |
+| 4. Respond to a meeting invite | `respond_to_invite` |
+| 6. Bulk unsubscribe from marketing emails | `bulk_unsubscribe` |
+| 7. Daily summary across all accounts | `daily_briefing` (today) or `week_ahead` (7 days) |
+| 8. Add the sender of an email as a contact | `contact_summary` (search-first variant) |
+| 10. Cross-account search for a topic | `find_emails_about` |
+
+The remaining scenarios (free-busy approximation, re-routing
+misdirected mail) don't have a prompt yet — drive those with the tools
+directly.
+
 ## 1. Triage the morning inbox
 
 Goal: quickly classify unread mail across all accounts and act on

--- a/src/CalendarMcp.Core/Tools/GetGuideTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetGuideTool.cs
@@ -93,6 +93,8 @@ public sealed class GetGuideTool(ILogger<GetGuideTool> logger)
         sb.AppendLine();
         sb.AppendLine("Call `get_guide` with `name=<topic>` (e.g. `get_guide(name=\"overview\")`) to read any guide below.");
         sb.AppendLine();
+        sb.AppendLine("**Prompts:** This server also exposes pre-built MCP prompt workflows (daily briefing, email triage, schedule meeting, forward with attachments, bulk unsubscribe, contact summary, and more). If your client supports prompts, prefer them over orchestrating tools by hand. See the `overview` guide for the full catalog.");
+        sb.AppendLine();
         sb.AppendLine("| Guide | Description |");
         sb.AppendLine("|---|---|");
         foreach (var n in names)


### PR DESCRIPTION
## Summary
- Guides now reference matching MCP prompts so clients that support prompts (e.g. Claude Desktop) use the one-shot starter instead of orchestrating tools by hand. `overview.md` gains a prompt-catalog table; `email.md`, `calendar.md`, `contacts.md`, and `scenarios.md` each call out which prompt wraps which pattern.
- Added three new prompts covering scenarios users get wrong most often when driving tools directly:
  - `respond_to_invite` — reviews invite with conflict check before responding from the correct account
  - `forward_with_attachments` — walks the two-step stash flow so attachment bytes never round-trip through the agent
  - `bulk_unsubscribe` — searches, unsubscribes via RFC `List-Unsubscribe`, and optionally deletes; gated on user confirmation because the action is hard to reverse
- No `Program.cs` changes needed — `.WithPrompts<EmailPrompts>()` / `.WithPrompts<CalendarPrompts>()` pick up new methods automatically.

## Test plan
- [x] `dotnet build` (full solution) passes — 0 errors, only pre-existing dependency CVE warnings
- [ ] Run stdio server in Claude Desktop and confirm the three new prompts appear in the prompt picker
- [ ] Invoke `respond_to_invite`, `forward_with_attachments`, `bulk_unsubscribe` end-to-end against a live M365 + Gmail account
- [ ] Confirm `get_guide(name="overview")` returns the updated prompt table and per-domain guides mention prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)