### PR TITLE
Warn when a provided calendarId is not found in the target account (#61)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.3.4</VersionPrefix>
+    <VersionPrefix>1.3.5</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: calendar-mcp
-          image: docker.io/rockylhotka/calendar-mcp-http:1.3.4
+          image: docker.io/rockylhotka/calendar-mcp-http:1.3.5
           ports:
             - containerPort: 8080
               name: http

--- a/src/CalendarMcp.Core/Tools/GetCalendarEventsTool.cs
+++ b/src/CalendarMcp.Core/Tools/GetCalendarEventsTool.cs
@@ -35,10 +35,18 @@ public sealed class GetCalendarEventsTool(
         //   - accountId provided        -> that single account
         //   - calendarId provided alone -> resolve the owning account automatically
         //   - neither provided          -> all enabled accounts
+        // When an explicit accountId is paired with a calendarId, we can't tell from an empty
+        // result whether the calendar is genuinely empty or the calendarId simply doesn't exist
+        // in that account. Validate it against ListCalendarsAsync and surface a warning if missing.
+        // The calendarId-only path (below) already validates via its account-resolution lookup,
+        // so this flag stays false there to avoid a redundant ListCalendarsAsync call.
+        var validateCalendarId = false;
+
         List<AccountInfo> validAccounts;
         if (!string.IsNullOrEmpty(accountId))
         {
             validAccounts = new List<AccountInfo> { await ToolGuard.RequireAccountAsync(accountRegistry, accountId) };
+            validateCalendarId = !string.IsNullOrEmpty(calendarId);
         }
         else if (!string.IsNullOrEmpty(calendarId))
         {
@@ -104,6 +112,34 @@ public sealed class GetCalendarEventsTool(
                 try
                 {
                     var provider = providerFactory.GetProvider(account!.Provider);
+
+                    if (validateCalendarId)
+                    {
+                        // Best-effort check that the supplied calendarId actually exists in this
+                        // account. If it doesn't, warn and skip the (pointless) events fetch.
+                        // A ListCalendarsAsync failure shouldn't block the read, so we fall through.
+                        try
+                        {
+                            var calendars = await provider.ListCalendarsAsync(account.Id, CancellationToken.None);
+                            if (!calendars.Any(c => c.Id == calendarId))
+                            {
+                                lock (warnings)
+                                {
+                                    warnings.Add(new
+                                    {
+                                        accountId = account.Id,
+                                        warning = $"calendarId '{calendarId}' was not found in account '{account.Id}'. Use list_calendars to obtain a valid calendar id."
+                                    });
+                                }
+                                return Enumerable.Empty<CalendarEvent>();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex, "Error validating calendarId {CalendarId} for account {AccountId}", calendarId, account.Id);
+                        }
+                    }
+
                     var events = await provider.GetCalendarEventsAsync(
                         account.Id, calendarId, resolvedStart, resolvedEnd, count, CancellationToken.None);
                     return events;

--- a/src/CalendarMcp.Tests/Tools/GetCalendarEventsToolTests.cs
+++ b/src/CalendarMcp.Tests/Tools/GetCalendarEventsToolTests.cs
@@ -210,6 +210,89 @@ public class GetCalendarEventsToolTests
     }
 
     [TestMethod]
+    public async Task GetCalendarEvents_AccountIdWithMissingCalendarId_WarnsAndReturnsEmpty()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var calendars = new List<CalendarInfo> { TestData.CreateCalendar(id: "cal-real", accountId: "acc-1") };
+
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync("acc-1")
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        var provExp = new IProviderServiceCreateExpectations();
+        provExp.Setups.ListCalendarsAsync("acc-1", Arg.Any<CancellationToken>())
+            .ReturnValue(Task.FromResult<IEnumerable<CalendarInfo>>(calendars));
+        // GetCalendarEventsAsync must NOT be called when the calendarId doesn't exist.
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        factExp.Setups.GetProvider("microsoft365").ReturnValue(provExp.Instance());
+
+        var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<GetCalendarEventsTool>.Instance);
+
+        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, "acc-1", "primary");
+        var doc = JsonDocument.Parse(result);
+
+        Assert.AreEqual(0, doc.RootElement.GetProperty("events").GetArrayLength());
+
+        var warnings = doc.RootElement.GetProperty("warnings");
+        Assert.AreEqual(1, warnings.GetArrayLength());
+        Assert.AreEqual("acc-1", warnings[0].GetProperty("accountId").GetString());
+        var warningText = warnings[0].GetProperty("warning").GetString();
+        Assert.IsTrue(warningText!.Contains("primary"));
+        Assert.IsTrue(warningText.Contains("acc-1"));
+        Assert.IsTrue(warningText.Contains("list_calendars"));
+
+        regExp.Verify();
+        factExp.Verify();
+        provExp.Verify();
+    }
+
+    [TestMethod]
+    public async Task GetCalendarEvents_AccountIdWithValidCalendarId_ReturnsEventsNoWarning()
+    {
+        var account = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");
+        var calendars = new List<CalendarInfo> { TestData.CreateCalendar(id: "cal-work", accountId: "acc-1") };
+        var events = new List<CalendarEvent>
+        {
+            TestData.CreateEvent(id: "ev1", accountId: "acc-1", subject: "Meeting",
+                start: new DateTime(2025, 1, 10, 15, 0, 0, DateTimeKind.Utc),
+                end: new DateTime(2025, 1, 10, 16, 0, 0, DateTimeKind.Utc))
+        };
+
+        var regExp = new IAccountRegistryCreateExpectations();
+        regExp.Setups.GetAccountAsync("acc-1")
+            .ReturnValue(Task.FromResult<AccountInfo?>(account));
+
+        var provExp = new IProviderServiceCreateExpectations();
+        provExp.Setups.ListCalendarsAsync("acc-1", Arg.Any<CancellationToken>())
+            .ReturnValue(Task.FromResult<IEnumerable<CalendarInfo>>(calendars));
+        provExp.Setups.GetCalendarEventsAsync(
+            "acc-1", Arg.Any<string?>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>(),
+            Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ReturnValue(Task.FromResult<IEnumerable<CalendarEvent>>(events));
+
+        var factExp = new IProviderServiceFactoryCreateExpectations();
+        // The provider is resolved once per account and reused for both the calendarId
+        // validation and the events fetch.
+        factExp.Setups.GetProvider("microsoft365").ReturnValue(provExp.Instance());
+
+        var tool = new GetCalendarEventsTool(regExp.Instance(), factExp.Instance(),
+            NullLogger<GetCalendarEventsTool>.Instance);
+
+        var result = await tool.GetCalendarEvents(TestTimeZone, Start, End, "acc-1", "cal-work");
+        var doc = JsonDocument.Parse(result);
+
+        Assert.AreEqual(1, doc.RootElement.GetProperty("events").GetArrayLength());
+        Assert.AreEqual("ev1", doc.RootElement.GetProperty("events")[0].GetProperty("id").GetString());
+        Assert.AreEqual(JsonValueKind.Null, doc.RootElement.GetProperty("warnings").ValueKind);
+
+        regExp.Verify();
+        factExp.Verify();
+        provExp.Verify();
+    }
+
+    [TestMethod]
     public async Task GetCalendarEvents_NullAccountIdWithCalendarId_SingleMatch_ResolvesAccount()
     {
         var acc1 = TestData.CreateAccount(id: "acc-1", provider: "microsoft365");


### PR DESCRIPTION
Closes #61.

## Problem

When `get_calendar_events` is called with an explicit `accountId` **and** a `calendarId` that doesn't exist in that account (e.g. `calendarId="primary"` against an Outlook/Graph account — `"primary"` is a Google convention), the provider returns `events: []` with no signal. The caller can't distinguish:

- "this calendar exists and is genuinely empty for the range", from
- "this calendarId doesn't exist in this account" (typo, wrong provider convention, stale ID).

Both read identically as a silent failure.

## Change

In the explicit-`accountId` + `calendarId` path, validate the `calendarId` against `ListCalendarsAsync`. If no calendar matches, add a per-account entry to the existing `warnings` channel and skip the pointless events fetch:

```json
{ "accountId": "rockyl", "warning": "calendarId 'primary' was not found in account 'rockyl'. Use list_calendars to obtain a valid calendar id." }
```

Design notes:
- Stays a **warning**, not an error — an empty-but-valid calendar is legitimate.
- A `ListCalendarsAsync` failure falls through to the normal read rather than blocking it (best-effort validation).
- The `calendarId`-only auto-resolve path already validates via its account-resolution lookup, so a `validateCalendarId` flag keeps that path from issuing a redundant `ListCalendarsAsync` call (no double-fetch).
- The all-accounts path passes no `calendarId`, so it's unaffected.

## Scope

Limited to `get_calendar_events` per the issue's source pointer. Generalizing to other `calendarId`-accepting reads (e.g. `get_calendar_event_details`) is a possible follow-up.

## Testing

- New: `accountId` + missing `calendarId` → events empty, warning present.
- New: `accountId` + valid `calendarId` → events returned, no warning.
- Full suite: 246 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)