### PR TITLE
Bump k8s deployment image to 1.3.7

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: calendar-mcp
-          image: docker.io/rockylhotka/calendar-mcp-http:1.3.6
+          image: docker.io/rockylhotka/calendar-mcp-http:1.3.7
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Updates the deployed image tag to `1.3.7` (the "primary" default-calendar alias fix from #66). Already built, pushed, and rolled out to the cluster; verified Test 3 (`rockyl` + `primary`) returns events with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)