### PR TITLE
Fix macOS Keychain support and M365 scope consistency

### DIFF
--- a/src/CalendarMcp.Cli/Commands/AddM365AccountCommand.cs
+++ b/src/CalendarMcp.Cli/Commands/AddM365AccountCommand.cs
@@ -87,7 +87,14 @@ public class AddM365AccountCommand : AsyncCommand<AddM365AccountCommand.Settings
             new TextPrompt<int>("[green]Priority[/] (higher = preferred, default is 0):")
                 .DefaultValue(0));
 
-        var scopes = CalendarMcp.Core.Constants.M365Scopes.WithFiles;
+        var defaultScopes = string.Join(",", CalendarMcp.Core.Constants.M365Scopes.WithFiles);
+        var scopesInput = AnsiConsole.Prompt(
+            new TextPrompt<string>(
+                "[green]Scopes[/] (comma-separated Graph permissions, or leave default for mail+calendar+contacts+files):")
+                .DefaultValue(defaultScopes)
+                .ShowDefaultValue(false));
+
+        var scopes = scopesInput.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[yellow]Starting authentication...[/]");
@@ -152,7 +159,8 @@ public class AddM365AccountCommand : AsyncCommand<AddM365AccountCommand.Settings
             var providerConfig = new Dictionary<string, string>
             {
                 { "TenantId", tenantId },
-                { "ClientId", clientId }
+                { "ClientId", clientId },
+                { "Scopes", string.Join(",", scopes) }
             };
 
             var newAccount = new Dictionary<string, object>

--- a/src/CalendarMcp.Core/Constants/OAuthScopes.cs
+++ b/src/CalendarMcp.Core/Constants/OAuthScopes.cs
@@ -58,6 +58,14 @@ public static class M365Scopes
         "Contacts.ReadWrite",
         "Files.Read"
     ];
+
+    /// <summary>
+    /// Minimal read-only calendar scope, for app registrations granted only Calendars.Read.
+    /// </summary>
+    public static readonly string[] CalendarsReadOnly =
+    [
+        "Calendars.Read"
+    ];
 }
 
 /// <summary>

--- a/src/CalendarMcp.Core/Providers/M365AuthenticationService.cs
+++ b/src/CalendarMcp.Core/Providers/M365AuthenticationService.cs
@@ -168,6 +168,12 @@ public class M365AuthenticationService : IM365AuthenticationService
         {
             storagePropertiesBuilder.WithLinuxUnprotectedFile();
         }
+        else if (OperatingSystem.IsMacOS())
+        {
+            storagePropertiesBuilder.WithMacKeyChain(
+                serviceName: "CalendarMcp.MsalCache",
+                accountName: cacheFileName);
+        }
 
         var storageProperties = storagePropertiesBuilder.Build();
 

--- a/src/CalendarMcp.Core/Providers/M365ProviderService.cs
+++ b/src/CalendarMcp.Core/Providers/M365ProviderService.cs
@@ -48,10 +48,17 @@ public class M365ProviderService : IM365ProviderService
             return null;
         }
 
+        // Use the scopes this account was actually consented for, if recorded; otherwise
+        // fall back to the historical default so existing configs keep working unchanged.
+        var scopes = account.ProviderConfig.TryGetValue("scopes", out var scopesValue) &&
+            !string.IsNullOrWhiteSpace(scopesValue)
+                ? scopesValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                : DefaultScopes;
+
         var token = await _authService.GetTokenSilentlyAsync(
             tenantId,
             clientId,
-            DefaultScopes,
+            scopes,
             accountId,
             cancellationToken);
 


### PR DESCRIPTION
## Summary

Two related fixes found while setting up an M365 account on macOS with
a least-privilege (`Calendars.Read`-only) app registration:

1. **macOS Keychain support was never wired up** (fixes #70).
   `StorageCreationPropertiesBuilder` special-cased Linux
   (`WithLinuxUnprotectedFile`) but never called `WithMacKeyChain(...)`
   for macOS, so MSAL's cache helper throws
   `Value cannot be null. (Parameter 'keyChainServiceName')` on first
   use, despite `security.md` documenting Keychain-backed storage as
   already implemented.

2. **`add-m365-account` and `M365ProviderService` requested different,
   hardcoded scope sets** (fixes #71). The CLI always requested
   `M365Scopes.WithFiles` at login; the provider always requested the
   separate `M365Scopes.Default` for silent token acquisition at
   runtime. For any app registration granted a narrower permission set
   than either hardcoded default, this mismatch causes every read call
   to silently fail (`AcquireTokenSilent` can't upgrade scope without
   interactive consent) and return an empty result with no visible
   error — see #72 for the related silent-failure issue, not addressed
   in this PR to keep the diff focused.

## Changes

- `M365AuthenticationService.GetOrCreateAppAsync`: add a macOS branch
  calling `WithMacKeyChain(serviceName, accountName)` alongside the
  existing Linux branch.
- `AddM365AccountCommand`: prompt for scopes (default: the previous
  `WithFiles` set, so existing behavior is unchanged if you accept the
  default), persist the chosen scopes to
  `ProviderConfig["Scopes"]`.
- `M365ProviderService.GetAccessTokenAsync`: read
  `ProviderConfig["Scopes"]` per-account when present, falling back to
  the historical `M365Scopes.Default` for accounts configured before
  this change (fully backward compatible).
- `OAuthScopes.cs`: add a `M365Scopes.CalendarsReadOnly` convenience
  constant for the calendar-only case.

## Testing

Built from source on macOS (arm64, net10.0). Verified end-to-end with
a real Entra app registration scoped to `Calendars.Read` only:
registered the app, ran `add-m365-account` with a custom (narrower)
scope, authenticated interactively, and confirmed `get_calendar_events`
/ `list_calendars` return real data via the MCP stdio server — prior to
this fix, both silently returned empty results due to the scope
mismatch in issue #71.

Also verified the default (no scopes entered, accept `WithFiles`
default) path still works unchanged, for backward compatibility with
existing configs that don't have a `Scopes` key.

Closes #70, #71.